### PR TITLE
Enhance partner verification

### DIFF
--- a/src/AplosConnector.Common/Services/Abstractions/IAplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/Abstractions/IAplosIntegrationService.cs
@@ -23,9 +23,9 @@ namespace AplosConnector.Common.Services.Abstractions
         Task<IEnumerable<PexAplosApiObject>> GetAplosFunds(Pex2AplosMappingModel mapping);
         Task<IEnumerable<PexAplosApiObject>> GetAplosTagCategories(Pex2AplosMappingModel mapping);
         Task<List<AplosApiTransactionDetail>> GetTransactions(Pex2AplosMappingModel mapping, DateTime startDate);
-        IAplosApiClient MakeAplosApiClient(Pex2AplosMappingModel mapping);
+        IAplosApiClient MakeAplosApiClient(Pex2AplosMappingModel mapping, AplosAuthenticationMode? overrideAuthenticationMode = null);
         Task Sync(Pex2AplosMappingModel mapping, ILogger log);
         Task<TransactionSyncResult> SyncTransaction(IEnumerable<(AllocationTagValue allocation, PexTagValuesModel pexTagValues)> allocationDetails, Pex2AplosMappingModel mapping, TransactionModel transaction, CardholderDetailsModel cardholderDetails);
-        Task<Pex2AplosMappingModel> InstallDefaultMappingIfNeeded(PexOAuthSessionModel session);
+        Task<Pex2AplosMappingModel> EnsureMappingInstalled(PexOAuthSessionModel session);
     }
 }

--- a/src/AplosConnector.Web/ClientApp/src/app/services/aplos.service.ts
+++ b/src/AplosConnector.Web/ClientApp/src/app/services/aplos.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Inject } from "@angular/core";
 import { HttpClient } from "@angular/common/http";
-import { Observable } from "rxjs";
+import { Observable, EMPTY } from "rxjs";
 
 import { retryWithBackoff } from "../operators/retryWithBackoff.operator";
 import { CacheRepositoryService } from './cache-repository.service';
@@ -29,12 +29,16 @@ export class AplosService {
   }
 
   getContact(sessionId: string, contactId: number): Observable<AplosObject> {
+    if (!contactId) return EMPTY;
+
     return this.cache.runAndCacheOrGetFromCache("Aplos.getContact"+contactId, this.httpClient
       .get<AplosObject>(`${this.buildUrl(sessionId, "Contact")}&aplosContactId=${contactId}`)
       .pipe(retryWithBackoff()), 60);
   }
 
   getFund(sessionId: string, fundId: number): Observable<AplosObject> {
+    if (!fundId) return EMPTY;
+
     return this.cache.runAndCacheOrGetFromCache("Aplos.getFund"+fundId, this.httpClient
       .get<AplosObject>(`${this.buildUrl(sessionId, "Fund")}&aplosFundId=${fundId}`)
       .pipe(retryWithBackoff()), 60);
@@ -54,6 +58,8 @@ export class AplosService {
   }
 
   getAccount(sessionId: string, bankAccountNumber: number): Observable<AplosAccount> {
+    if (!bankAccountNumber) return EMPTY;
+
     return this.cache.runAndCacheOrGetFromCache("Aplos.getBankAccount"+bankAccountNumber, this.httpClient
         .get<AplosAccount>(`${this.buildUrl(sessionId, "Account")}&accountNumber=${bankAccountNumber}`)
       .pipe(retryWithBackoff()), 60);

--- a/src/AplosConnector.Web/Controllers/MappingController.cs
+++ b/src/AplosConnector.Web/Controllers/MappingController.cs
@@ -126,11 +126,7 @@ namespace AplosConnector.Web.Controllers
             var session = await _pexOAuthSessionStorage.GetBySessionGuidAsync(sessionGuid);
             if (session == null) return Unauthorized();
 
-            var mapping = await _pex2AplosMappingStorage.GetByBusinessAcctIdAsync(session.PEXBusinessAcctId);
-            if (mapping == null)
-            {
-                mapping = await _aplosIntegrationService.InstallDefaultMappingIfNeeded(session);
-            }
+            var mapping = await _aplosIntegrationService.EnsureMappingInstalled(session);
 
             var result = new AplosAuthenticationStatusModel
             {

--- a/src/AplosConnector.Web/Controllers/SessionController.cs
+++ b/src/AplosConnector.Web/Controllers/SessionController.cs
@@ -113,7 +113,7 @@ namespace AplosConnector.Web.Controllers
             };
             await _pexOAuthSessionStorage.CreateAsync(session);
 
-            await _aplosIntegrationService.InstallDefaultMappingIfNeeded(session);
+            await _aplosIntegrationService.EnsureMappingInstalled(session);
 
             return new TokenModel { Token = sessionGuid.ToString() };
         }
@@ -132,7 +132,7 @@ namespace AplosConnector.Web.Controllers
             };
             await _pexOAuthSessionStorage.CreateAsync(session);
 
-            await _aplosIntegrationService.InstallDefaultMappingIfNeeded(session);
+            await _aplosIntegrationService.EnsureMappingInstalled(session);
         }
 
         [HttpDelete, Route("")]


### PR DESCRIPTION
- Add AplosAccountID / verification to daily sync and ensure it occurs on login
- Force AplosApiClient to use PartnerAuthenticationMode when verifying partner credentials
- Handle expected error response in ValidateAplosAccountIds

Resolves [AB#42677](https://pexcard.visualstudio.com/1e893f43-a87f-46d1-abc4-e68d9e66c1ef/_workitems/edit/42677)