### PR TITLE
Dedupe Aplos tag categories

### DIFF
--- a/src/Aplos.Api.Client/AplosApiClient.cs
+++ b/src/Aplos.Api.Client/AplosApiClient.cs
@@ -306,7 +306,7 @@ namespace Aplos.Api.Client
                 HttpMethod.Get,
                 APLOS_ENDPOINT_TAGS);
 
-            var result = new List<AplosApiTagCategoryDetail>(response.Data.TagCategories);
+            var rawTagCategories = new List<AplosApiTagCategoryDetail>(response.Data.TagCategories);
 
             while (!string.IsNullOrEmpty(response.Links?.Next))
             {
@@ -314,8 +314,23 @@ namespace Aplos.Api.Client
                     HttpMethod.Get,
                     response.Links.Next.Replace("/api/v1/", ""));
 
-                result.AddRange(response.Data.TagCategories);
+                rawTagCategories.AddRange(response.Data.TagCategories);
             }
+
+            var result = new List<AplosApiTagCategoryDetail>();
+            foreach (var tagCategory in rawTagCategories)
+            {
+                var existingCategory = result.Find(r => r.Id == tagCategory.Id);
+                if (existingCategory == null)
+                {
+                    result.Add(tagCategory);
+                }
+                else
+                {
+                    existingCategory.TagGroups.AddRange(tagCategory.TagGroups);
+                }
+            }
+
             return result;
         }
 

--- a/src/Aplos.Api.Client/AplosApiClient.cs
+++ b/src/Aplos.Api.Client/AplosApiClient.cs
@@ -317,6 +317,8 @@ namespace Aplos.Api.Client
                 rawTagCategories.AddRange(response.Data.TagCategories);
             }
 
+            //Handle when Aplos sends the same tag category more than once.
+            //This happens when there are enough tags to spill over into a new page. The tag category is repeated from a previous page, but the tag groups and tags within those groups are unique per page.
             var result = new List<AplosApiTagCategoryDetail>();
             foreach (var tagCategory in rawTagCategories)
             {

--- a/tests/Aplos.Api.Client.Tests/AplosApiClientTests.cs
+++ b/tests/Aplos.Api.Client.Tests/AplosApiClientTests.cs
@@ -607,7 +607,7 @@ namespace Aplos.Api.Client.Tests
             Assert.Equal("Departments", tagCategory2.Name);
             Assert.Equal("advanced", tagCategory2.Type);
             Assert.NotNull(tagCategory2.TagGroups);
-            Assert.Equal(1, tagCategory2.TagGroups.Count);
+            Assert.Equal(2, tagCategory2.TagGroups.Count);
             {
                 var tagCategory2Group1 = tagCategory2.TagGroups[0];
                 Assert.Equal("89295", tagCategory2Group1.Id);
@@ -624,6 +624,18 @@ namespace Aplos.Api.Client.Tests
                     Assert.Equal("120737", tagCategory1Group1Tag2.Id);
                     Assert.Equal("Operations", tagCategory1Group1Tag2.Name);
                     Assert.Null(tagCategory1Group1Tag2.SubTags);
+                }
+
+                var tagCategory2Group2 = tagCategory2.TagGroups[1];
+                Assert.Equal("892952", tagCategory2Group2.Id);
+                Assert.Equal("PEX Department2", tagCategory2Group2.Name);
+                Assert.NotNull(tagCategory2Group2.Tags);
+                Assert.Equal(1, tagCategory2Group2.Tags.Count);
+                {
+                    var tagCategory2Group2Tag1 = tagCategory2Group2.Tags[0];
+                    Assert.Equal("91299", tagCategory2Group2Tag1.Id);
+                    Assert.Equal("Sales", tagCategory2Group2Tag1.Name);
+                    Assert.Null(tagCategory2Group2Tag1.SubTags);
                 }
             }
         }

--- a/tests/Aplos.Api.Client.Tests/Samples/Response/GET_tags.json
+++ b/tests/Aplos.Api.Client.Tests/Samples/Response/GET_tags.json
@@ -90,6 +90,23 @@
                         ]
                     }
                 ]
+            },
+            {
+                "id": 87404,
+                "name": "Departments",
+                "type": "advanced",
+                "tag_groups": [
+                    {
+                        "id": 892952,
+                        "name": "PEX Department2",
+                        "tags": [
+                            {
+                                "id": 91299,
+                                "name": "Sales"
+                            }
+                        ]
+                    }
+                ]
             }
         ]
     }


### PR DESCRIPTION
Handle when Aplos sends the same tag category more than once. This happens when there are enough tags to spill over into a new page. The tag category is repeated from a previous page, but the tag groups and tags within those groups are unique per page.

[AB#43619](https://pexcard.visualstudio.com/1e893f43-a87f-46d1-abc4-e68d9e66c1ef/_workitems/edit/43619)