### PR TITLE
Make Aplos tags optional

### DIFF
--- a/src/AplosConnector.Web/ClientApp/src/app/connect/connect.component.html
+++ b/src/AplosConnector.Web/ClientApp/src/app/connect/connect.component.html
@@ -435,7 +435,11 @@
               <th class="left">Aplos Tag</th>
               <th class="left">PEX Tag</th>
               <th class="left">Sync tag options from Aplos</th>
-              <th></th>
+              <th>
+                <button type="button" class="btn btn-primary btn-sm btn-icon" aria-label="add" (click)="addTagMappingElement()">
+                  <clr-icon shape="plus" size="12"></clr-icon>
+                </button>
+              </th>
             </tr>
           </thead>
           <tbody formArrayName="tagMappings">
@@ -466,11 +470,8 @@
                 </clr-toggle-wrapper>
               </td>
               <td>
-                <button type="button" class="btn btn-danger btn-sm btn-icon" aria-label="add" (click)="deleteTagMappingElement(i)" *ngIf="this.getTagMappingFormElements().length > 1">
+                <button type="button" class="btn btn-danger btn-sm btn-icon" aria-label="add" (click)="deleteTagMappingElement(i)">
                   <clr-icon shape="trash" size="12"></clr-icon>
-                </button>
-                <button type="button" class="btn btn-primary btn-sm btn-icon" aria-label="add" (click)="addTagMappingElement()">
-                  <clr-icon shape="plus" size="12"></clr-icon>
                 </button>
               </td>
             </tr>

--- a/src/AplosConnector.Web/ClientApp/src/app/connect/connect.component.html
+++ b/src/AplosConnector.Web/ClientApp/src/app/connect/connect.component.html
@@ -390,7 +390,11 @@
             <th class="left">Aplos field</th>
             <th class="left">PEX Tag</th>
             <th class="left" *ngIf="getExpenseAccountFormElements().length == 1">Sync Tag options from Aplos</th>
-            <th></th>
+            <th>
+              <button type="button" class="btn btn-primary btn-sm btn-icon" aria-label="add" (click)="addExpenseAccountElement()">
+                <clr-icon shape="plus" size="12"></clr-icon>
+              </button>
+            </th>
           </tr>
         </thead>
 
@@ -417,9 +421,6 @@
             <td>
               <button type="button" class="btn btn-danger btn-sm btn-icon" aria-label="add" (click)="deleteExpenseAccountElement(i)" *ngIf="this.getExpenseAccountFormElements().length > 1">
                 <clr-icon shape="trash" size="12"></clr-icon>
-              </button>
-              <button type="button" class="btn btn-primary btn-sm btn-icon" aria-label="add" (click)="addExpenseAccountElement()">
-                <clr-icon shape="plus" size="12"></clr-icon>
               </button>
             </td>
           </tr>

--- a/src/AplosConnector.Web/ClientApp/src/app/connect/connect.component.ts
+++ b/src/AplosConnector.Web/ClientApp/src/app/connect/connect.component.ts
@@ -349,9 +349,6 @@ export class ConnectComponent implements OnInit {
         }
       );
     }
-    else {
-      this.addTagMappingElement();
-    }
   }
 
   private validatePexSetup() {


### PR DESCRIPTION
- Don't add a mapping record by default
- Allow users to delete all mapping records
- Make expense category UX consistent

[AB#43619](https://pexcard.visualstudio.com/1e893f43-a87f-46d1-abc4-e68d9e66c1ef/_workitems/edit/43619)