### PR TITLE
Ensure unique account names in PEX tags

### DIFF
--- a/src/AplosConnector.Common/Services/AplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/AplosIntegrationService.cs
@@ -231,7 +231,27 @@ namespace AplosConnector.Common.Services
 
         public async Task<IEnumerable<PexAplosApiObject>> GetAplosExpenseAccounts(Pex2AplosMappingModel mapping, string aplosAccountCategory = null)
         {
-            return await GetAplosAccounts(mapping, AplosApiClient.APLOS_ACCOUNT_CATEGORY_EXPENSE);
+            var accounts = await GetAplosAccounts(mapping, AplosApiClient.APLOS_ACCOUNT_CATEGORY_EXPENSE);
+
+            var uniqueAccounts = new Dictionary<string, PexAplosApiObject>(accounts.Count());
+            foreach (var account in accounts)
+            {
+                string accountName = account.Name;
+                if (uniqueAccounts.TryGetValue(accountName, out PexAplosApiObject existingAccount))
+                {
+                    existingAccount.Name = DedupeAccountName(existingAccount);
+                    accountName = DedupeAccountName(account);
+                }
+
+                uniqueAccounts.Add(accountName, account);
+            }
+
+            return uniqueAccounts.Values;
+
+            string DedupeAccountName(PexAplosApiObject account)
+            {
+                return $"{account.Name} ({account.Id})";
+            }
         }
 
         public async Task<IEnumerable<PexAplosApiObject>> GetAplosAccounts(Pex2AplosMappingModel mapping, string aplosAccountCategory = null)

--- a/src/AplosConnector.Common/Services/AplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/AplosIntegrationService.cs
@@ -245,6 +245,11 @@ namespace AplosConnector.Common.Services
 
         public IEnumerable<PexAplosApiObject> DedupeAplosAccounts(IEnumerable<PexAplosApiObject> aplosAccounts)
         {
+            if (aplosAccounts == null)
+            {
+                return Enumerable.Empty<PexAplosApiObject>();
+            }
+
             var uniqueAccounts = new Dictionary<string, PexAplosApiObject>(aplosAccounts.Count());
             foreach (var account in aplosAccounts)
             {

--- a/tests/AplosConnector.Common.Tests/AplosIntegrationServiceTests.cs
+++ b/tests/AplosConnector.Common.Tests/AplosIntegrationServiceTests.cs
@@ -111,7 +111,7 @@ namespace AplosConnector.Common.Tests
         }
 
         [Fact]
-        public async Task GetAplosAccounts_ReturnsNull_WhenAplosAccountsNotFound()
+        public async Task GetAplosAccounts_ReturnsEmptyCollection_WhenAplosAccountsNotFound()
         {
             //Arrange
             _mockAplosApiClient
@@ -128,7 +128,7 @@ namespace AplosConnector.Common.Tests
             IEnumerable<PexAplosApiObject> actualMappedAplosAccount = await service.GetAplosAccounts(GetMapping());
 
             //Assert
-            Assert.Null(actualMappedAplosAccount);
+            Assert.NotNull(actualMappedAplosAccount);
         }
 
         [Fact]


### PR DESCRIPTION
Aplos allows the same account name but with a different account number. Tags in PEX must have both a unique value and a unique name/display as. This will append the account number to the account name when syncing accounts to PEX tags so that it can be unique.