### PR TITLE
Use current Node.js LTS version

### DIFF
--- a/azure-pipelines-1.yml
+++ b/azure-pipelines-1.yml
@@ -46,7 +46,7 @@ steps:
 
 - task: NodeTool@0
   inputs:
-    versionSpec: '10.x'
+    versionSpec: '16.x'
   displayName: 'Install node.js'
 
 - script: |

--- a/azure-pipelines-1.yml
+++ b/azure-pipelines-1.yml
@@ -46,7 +46,7 @@ steps:
 
 - task: NodeTool@0
   inputs:
-    versionSpec: '16.x'
+    versionSpec: '14.x'
   displayName: 'Install node.js'
 
 - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,6 +26,11 @@ steps:
     packageType: 'sdk'
     version: '$(dotnetVersion).x'
 
+- task: NodeTool@0
+  inputs:
+    versionSpec: '14.x'
+  displayName: 'Install node.js'
+
 - task: SonarCloudPrepare@1
   inputs:
     SonarCloud: 'SonarCloud - tbaker'


### PR DESCRIPTION
Version 10.x is past end of life and pipelines started failing when using it.

[AB#46539](https://pexcard.visualstudio.com/1e893f43-a87f-46d1-abc4-e68d9e66c1ef/_workitems/edit/46539)