### PR TITLE
Update SDK and save sync errors to SyncNotes for Tags

### DIFF
--- a/src/AplosConnector.Common/AplosConnector.Common.csproj
+++ b/src/AplosConnector.Common/AplosConnector.Common.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.2.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.13" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="PexCard.Api.Client.Core" Version="1.11.0" />
+    <PackageReference Include="PexCard.Api.Client.Core" Version="1.12.0" />
     <PackageReference Include="System.Threading.Tasks" Version="4.3.0" />
     <PackageReference Include="Microsoft.Azure.Storage.Common" Version="11.2.2" />
     <PackageReference Include="Polly" Version="7.2.1" />

--- a/src/AplosConnector.Common/Services/AplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/AplosIntegrationService.cs
@@ -521,17 +521,23 @@ namespace AplosConnector.Common.Services
                 IEnumerable<AplosApiTagDetail> flattenedAplosTags = GetFlattenedAplosTagValues(aplosTagCategory, cancellationToken);
                 IEnumerable<PexAplosApiObject> aplosTagsToSync = _aplosIntegrationMappingService.Map(flattenedAplosTags);
 
-                pexTag.UpsertTagOptions(aplosTagsToSync, out var syncCount);
 
                 SyncStatus syncStatus;
+                int syncCount = 0;
+                string syncNotes = null;
+
                 try
                 {
+                    pexTag.UpsertTagOptions(aplosTagsToSync, out syncCount);
+
                     await _pexApiClient.UpdateDropdownTag(mapping.PEXExternalAPIToken, pexTag.Id, pexTag, cancellationToken);
                     syncStatus = SyncStatus.Success;
                 }
                 catch (Exception ex)
                 {
                     syncStatus = SyncStatus.Failed;
+                    syncNotes = $"Error updating TagId {pexTag.Id}: {ex.Message}";
+
                     log.LogError(ex, $"Error updating TagId {pexTag.Id}");
                 }
 
@@ -540,7 +546,8 @@ namespace AplosConnector.Common.Services
                     PEXBusinessAcctId = mapping.PEXBusinessAcctId,
                     SyncType = $"Tag Values ({aplosTagCategory.Name})",
                     SyncStatus = syncStatus.ToString(),
-                    SyncedRecords = syncCount
+                    SyncedRecords = syncCount,
+                    SyncNotes = syncNotes
                 };
                 await _resultStorage.CreateAsync(result, cancellationToken);
             }
@@ -634,17 +641,23 @@ namespace AplosConnector.Common.Services
             }
 
             var aplosFunds = await GetAplosFunds(mapping, cancellationToken);
-            fundsTag.UpsertTagOptions(aplosFunds, out var syncCount);
 
             SyncStatus syncStatus;
+            int syncCount = 0;
+            string syncNotes = null;
+
             try
             {
+                fundsTag.UpsertTagOptions(aplosFunds, out syncCount);
+
                 await _pexApiClient.UpdateDropdownTag(mapping.PEXExternalAPIToken, fundsTag.Id, fundsTag, cancellationToken);
                 syncStatus = SyncStatus.Success;
             }
             catch (Exception ex)
             {
                 syncStatus = SyncStatus.Failed;
+                syncNotes = $"Error updating TagId {fundsTag.Id}: {ex.Message}";
+
                 log.LogError(ex, $"Error updating TagId {fundsTag.Id}");
             }
 
@@ -653,7 +666,8 @@ namespace AplosConnector.Common.Services
                 PEXBusinessAcctId = mapping.PEXBusinessAcctId,
                 SyncType = "Tag Values (Funds)",
                 SyncStatus = syncStatus.ToString(),
-                SyncedRecords = syncCount
+                SyncedRecords = syncCount,
+                SyncNotes = syncNotes
             };
             await _resultStorage.CreateAsync(result, cancellationToken);
         }
@@ -706,17 +720,23 @@ namespace AplosConnector.Common.Services
                 return;
             }
 
-            accountsTag.UpsertTagOptions(accounts, out var syncCount);
 
             SyncStatus syncStatus;
+            int syncCount = 0;
+            string syncNotes = null;
+
             try
             {
+                accountsTag.UpsertTagOptions(accounts, out syncCount);
+
                 await _pexApiClient.UpdateDropdownTag(model.PEXExternalAPIToken, accountsTag.Id, accountsTag);
                 syncStatus = SyncStatus.Success;
             }
             catch (Exception ex)
             {
                 syncStatus = SyncStatus.Failed;
+                syncNotes = $"Error updating TagId {accountsTag.Id}: {ex.Message}";
+
                 log.LogError(ex, $"Error updating TagId {accountsTag.Id}");
             }
 
@@ -725,7 +745,8 @@ namespace AplosConnector.Common.Services
                 PEXBusinessAcctId = model.PEXBusinessAcctId,
                 SyncType = "Tag Values (Accounts)",
                 SyncStatus = syncStatus.ToString(),
-                SyncedRecords = syncCount
+                SyncedRecords = syncCount,
+                SyncNotes = syncNotes
             };
             await _resultStorage.CreateAsync(result, cancellationToken);
         }

--- a/src/AplosConnector.SyncWorker/AplosConnector.SyncWorker.csproj
+++ b/src/AplosConnector.SyncWorker/AplosConnector.SyncWorker.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="3.1.13" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.11" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="PexCard.Api.Client" Version="1.11.0" />
+    <PackageReference Include="PexCard.Api.Client" Version="1.12.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Aplos.Api.Client\Aplos.Api.Client.csproj" />

--- a/src/AplosConnector.Web/AplosConnector.Web.csproj
+++ b/src/AplosConnector.Web/AplosConnector.Web.csproj
@@ -41,9 +41,9 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.13" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="3.1.13" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.5" />
-    <PackageReference Include="PexCard.Api.Client" Version="1.11.0" />
+    <PackageReference Include="PexCard.Api.Client" Version="1.12.0" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.1.13" />
-    <PackageReference Include="PexCard.Api.Client.Core" Version="1.11.0" />
+    <PackageReference Include="PexCard.Api.Client.Core" Version="1.12.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Update SDK for latest tag option validation.
- Save tag sync error messages to SyncNotes.
- [AB#48092](https://pexcard.visualstudio.com/1e893f43-a87f-46d1-abc4-e68d9e66c1ef/_workitems/edit/48092)