### PR TITLE
Increase PEX API Client timeout

### DIFF
--- a/src/AplosConnector.Common/Models/Settings/AppSettingsModel.cs
+++ b/src/AplosConnector.Common/Models/Settings/AppSettingsModel.cs
@@ -12,6 +12,7 @@ namespace AplosConnector.Common.Models.Settings
         public string AplosApiClientId { get; set; }
         public string AplosApiClientSecret { get; set; }
         public Uri PEXAPIBaseURL { get; set; }
+        public int PEXAPITimeout { get; set; } = 100;
         public string CorsAllowedOrigins { get; set; }
 
         public string DataProtectionApplicationName { get; set; }

--- a/src/AplosConnector.SyncWorker/Startup.cs
+++ b/src/AplosConnector.SyncWorker/Startup.cs
@@ -41,6 +41,7 @@ namespace AplosConnector.SyncWorker
             builder.Services.AddHttpClient();
             builder.Services.AddHttpClient<IPexApiClient, PexApiClient>((client) =>
             {
+                client.Timeout = TimeSpan.FromMinutes(5);
                 client.BaseAddress = new Uri(Environment.GetEnvironmentVariable("PEXAPIBaseURL", EnvironmentVariableTarget.Process));
             })
             .AddPolicyHandler(GetPexRetryPolicy());

--- a/src/AplosConnector.SyncWorker/Startup.cs
+++ b/src/AplosConnector.SyncWorker/Startup.cs
@@ -41,8 +41,14 @@ namespace AplosConnector.SyncWorker
             builder.Services.AddHttpClient();
             builder.Services.AddHttpClient<IPexApiClient, PexApiClient>((client) =>
             {
-                client.Timeout = TimeSpan.FromMinutes(5);
                 client.BaseAddress = new Uri(Environment.GetEnvironmentVariable("PEXAPIBaseURL", EnvironmentVariableTarget.Process));
+
+                var pexApiTimeoutSetting = Environment.GetEnvironmentVariable("PEXAPITimeout", EnvironmentVariableTarget.Process);
+                if (!int.TryParse(pexApiTimeoutSetting, out var pexApiTimeout))
+                {
+                    pexApiTimeout = 100;
+                }
+                client.Timeout = TimeSpan.FromSeconds(pexApiTimeout);
             })
             .AddPolicyHandler(GetPexRetryPolicy());
 

--- a/src/AplosConnector.Web/Startup.cs
+++ b/src/AplosConnector.Web/Startup.cs
@@ -22,6 +22,7 @@ using Microsoft.Azure.KeyVault;
 using Microsoft.Azure.Services.AppAuthentication;
 using Microsoft.Azure.Storage;
 using Microsoft.Azure.Storage.Blob;
+using System;
 
 namespace AplosConnector.Web
 {
@@ -54,6 +55,7 @@ namespace AplosConnector.Web
             services.AddHttpClient<IPexApiClient, PexApiClient>((client) =>
             {
                 client.BaseAddress = appSettings.PEXAPIBaseURL;
+                client.Timeout = TimeSpan.FromSeconds(appSettings.PEXAPITimeout);
             })
             .AddPolicyHandler(GetPexRetryPolicy());
 

--- a/src/AplosConnector.Web/appsettings.json
+++ b/src/AplosConnector.Web/appsettings.json
@@ -20,6 +20,7 @@
     "AplosApiClientSecret": "OBTAIN_FROM_APLOS",
     "AplosApiBaseURL": "https://www.aplos.com/hermes/api/v1/",
     "PEXAPIBaseURL": "https://sandbox-coreapi.pexcard.com/",
+    "PEXAPITimeout": 100,
 
     "DataProtectionApplicationName": "",
     "DataProtectionBlobContainer": "",


### PR DESCRIPTION
#AB56952

- Increase PEX API Client timeout to 5 minutes for large txn requests.
  - Long term solution - do smaller date range batches.