### PR TITLE
Improve Aplos Tag Matching Algorithm

### DIFF
--- a/src/AplosConnector.Common/AplosConnector.Common.csproj
+++ b/src/AplosConnector.Common/AplosConnector.Common.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.2.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.24" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="PexCard.Api.Client.Core" Version="1.26.0" />
+    <PackageReference Include="PexCard.Api.Client.Core" Version="1.30.0" />
     <PackageReference Include="System.Threading.Tasks" Version="4.3.0" />
     <PackageReference Include="Microsoft.Azure.Storage.Common" Version="11.2.2" />
     <PackageReference Include="Polly" Version="7.2.1" />

--- a/src/AplosConnector.Common/Models/Aplos/PexAplosApiObject.cs
+++ b/src/AplosConnector.Common/Models/Aplos/PexAplosApiObject.cs
@@ -5,9 +5,11 @@ namespace AplosConnector.Common.Models.Aplos
     public class PexAplosApiObject : IMatchableEntity
     {
         public string Id { get; set; }
+
         public string Name { get; set; }
 
-        public string EntityId => Id;
-        public string EntityName => Name;
+        string IMatchableEntity.EntityId => Id;
+
+        string IMatchableEntity.EntityName => Name;
     }
 }

--- a/src/AplosConnector.Common/Services/AplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/AplosIntegrationService.cs
@@ -960,7 +960,7 @@ namespace AplosConnector.Common.Services
                                 var allocationFundEntityId = aplosFunds.FindMatchingEntity(allocationFundTagOptionValue, allocationFundTagOptionName, ':')?.Id;
                                 if (allocationFundEntityId == null)
                                 {
-                                    log.LogWarning($"Could not match PEX expense account tag '{nameof(allocationFundTagOptionName)}' / '{allocationFundTagOptionValue}' with an Aplos fund entity.");
+                                    log.LogWarning($"Could not match PEX expense account tag option '{nameof(allocationFundTagOptionName)}' / '{allocationFundTagOptionValue}' with an Aplos fund entity.");
                                 }
                                 else
                                 {
@@ -999,7 +999,7 @@ namespace AplosConnector.Common.Services
                                 var allocationExpenseAccountEntityId = aplosExpenseAccounts.FindMatchingEntity(allocationExpenseAccountTagOptionValue, allocationExpenseAccountTagOptionName, ':')?.Id;
                                 if (allocationExpenseAccountEntityId == null)
                                 {
-                                    log.LogWarning($"Could not match PEX expense account tag '{nameof(allocationExpenseAccountTagOptionName)}' / '{allocationExpenseAccountTagOptionValue}' with an Aplos expense account entity.");
+                                    log.LogWarning($"Could not match PEX expense account tag option '{nameof(allocationExpenseAccountTagOptionName)}' / '{allocationExpenseAccountTagOptionValue}' with an Aplos expense account entity.");
                                 }
                                 else
                                 {
@@ -1031,7 +1031,7 @@ namespace AplosConnector.Common.Services
 
                                         if (allocationTagEntityId is null)
                                         {
-                                            log.LogWarning($"Could not match PEX tag '{nameof(allocationTagOptionName)}' / '{allocationTagOptionValue}' with an Aplos tag entity.");
+                                            log.LogWarning($"Could not match PEX tag option '{nameof(allocationTagOptionName)}' / '{allocationTagOptionValue}' with an Aplos tag entity.");
                                         }
                                         else
                                         {

--- a/src/AplosConnector.Common/Services/AplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/AplosIntegrationService.cs
@@ -976,6 +976,10 @@ namespace AplosConnector.Common.Services
                                         }
                                     }
                                 }
+                                else
+                                {
+                                    log.LogInformation($"No PEX fund tag on allocation {allocation.Amount:C}.");
+                                }
 
                                 string expenseAccountTagId = null;
                                 TagValueItem expenseAccountTag = null;
@@ -1024,13 +1028,14 @@ namespace AplosConnector.Common.Services
                                         var allocationTag = allocation.GetTagValue(tagMapping.PexTagId);
                                         if (allocationTag == null || allocationTag.TagId == mapping.PexTaxTagId)
                                         {
+                                            log.LogInformation($"No PEX tag {tagMapping.PexTagId} on allocation {allocation.Amount:C}");
                                             continue;
                                         }
 
                                         var allocationTagDefinition = dropdownTags.FirstOrDefault(t => t.Id.Equals(tagMapping.PexTagId, StringComparison.InvariantCultureIgnoreCase));
                                         var allocationTagOptionValue = allocationTag.Value?.ToString();
                                         var allocationTagOptionName = allocationTag.GetTagOptionName(allocationTagDefinition?.Options);
-                                        var allocationTagEntityId = aplosTags.FindMatchingEntity(allocationTag.Value.ToString(), allocationTagOptionName, ':')?.Id;
+                                        var allocationTagEntityId = aplosTags.FindMatchingEntity(allocationTagOptionValue, allocationTagOptionName, ':')?.Id;
                                         if (allocationTagEntityId is null)
                                         {
                                             log.LogWarning($"Could not match PEX tag '{allocationTagDefinition?.Name}' option ['{allocationTagOptionName}' : '{allocationTagOptionValue}'] with an Aplos tag entity.");
@@ -1068,7 +1073,7 @@ namespace AplosConnector.Common.Services
 
                         if (!string.IsNullOrEmpty(syncIneligibilityReason))
                         {
-                            log.LogInformation(syncIneligibilityReason);
+                            log.LogWarning(syncIneligibilityReason);
                             continue;
                         }
 

--- a/src/AplosConnector.Common/Services/AplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/AplosIntegrationService.cs
@@ -959,20 +959,21 @@ namespace AplosConnector.Common.Services
                                     var fundTagDefinition = dropdownTags.FirstOrDefault(t => t.Id.Equals(mapping.PexFundsTagId, StringComparison.InvariantCultureIgnoreCase));
                                     var allocationFundTagOptionValue = allocationFundTag?.Value?.ToString();
                                     var allocationFundTagOptionName = allocationFundTag?.GetTagOptionName(fundTagDefinition?.Options);
-                                    var allocationFundEntityId = aplosFunds.FindMatchingEntity(allocationFundTagOptionValue, allocationFundTagOptionName, ':')?.Id;
-                                    if (allocationFundEntityId == null)
+                                    var allocationFundEntity = aplosFunds.FindMatchingEntity(allocationFundTagOptionValue, allocationFundTagOptionName, ':');
+                                    if (allocationFundEntity == null)
                                     {
                                         log.LogWarning($"Could not match PEX fund tag '{fundTagDefinition?.Name}' option ['{allocationFundTagOptionName}' : '{allocationFundTagOptionValue}'] with an Aplos fund entity.");
                                     }
                                     else
                                     {
-                                        if (int.TryParse(allocationFundEntityId, out var aplosFundId))
+                                        if (int.TryParse(allocationFundEntity.Id, out var aplosFundId))
                                         {
+                                            log.LogInformation($"Matched PEX fund tag '{fundTagDefinition?.Name}' option ['{allocationFundTagOptionName}' : '{allocationFundTagOptionValue}'] with Aplos fund entity '{allocationFundEntity.Name}' ({allocationFundEntity.Id}).");
                                             pexTagValues.AplosFundId = aplosFundId;
                                         }
                                         else
                                         {
-                                            log.LogWarning($"Could not parse Aplos expense fund id '{allocationFundEntityId}' into a int.");
+                                            log.LogWarning($"Could not parse Aplos expense fund id '{allocationFundEntity.Id}' into a int.");
                                         }
                                     }
                                 }
@@ -1003,20 +1004,21 @@ namespace AplosConnector.Common.Services
                                 var expenseAccountTagDefinition = dropdownTags.FirstOrDefault(t => t.Id.Equals(expenseAccountTagId, StringComparison.InvariantCultureIgnoreCase));
                                 var allocationExpenseAccountTagOptionName = expenseAccountTag.GetTagOptionName(expenseAccountTagDefinition?.Options);
                                 var allocationExpenseAccountTagOptionValue = expenseAccountTag.Value?.ToString();
-                                var allocationExpenseAccountEntityId = aplosExpenseAccounts.FindMatchingEntity(allocationExpenseAccountTagOptionValue, allocationExpenseAccountTagOptionName, ':')?.Id;
-                                if (allocationExpenseAccountEntityId == null)
+                                var allocationExpenseAccountEntity = aplosExpenseAccounts.FindMatchingEntity(allocationExpenseAccountTagOptionValue, allocationExpenseAccountTagOptionName, ':');
+                                if (allocationExpenseAccountEntity == null)
                                 {
                                     log.LogWarning($"Could not match PEX expense account tag '{expenseAccountTagDefinition?.Name}' option ['{allocationExpenseAccountTagOptionName}' : '{allocationExpenseAccountTagOptionValue}'] with an Aplos expense account entity.");
                                 }
                                 else
                                 {
-                                    if (decimal.TryParse(allocationExpenseAccountEntityId, out decimal aplosTransactionAccountNumber))
+                                    if (decimal.TryParse(allocationExpenseAccountEntity.Id, out decimal aplosTransactionAccountNumber))
                                     {
+                                        log.LogInformation($"Matched PEX expense account tag '{expenseAccountTagDefinition?.Name}' option ['{allocationExpenseAccountTagOptionName}' : '{allocationExpenseAccountTagOptionValue}'] with Aplos expense account entity '{allocationExpenseAccountEntity.Name}' ({allocationExpenseAccountEntity.Id}).");
                                         pexTagValues.AplosTransactionAccountNumber = aplosTransactionAccountNumber;
                                     }
                                     else
                                     {
-                                        log.LogWarning($"Could not parse Aplos expense account id '{allocationExpenseAccountEntityId}' into a decimal.");
+                                        log.LogWarning($"Could not parse Aplos expense account id '{allocationExpenseAccountEntity.Id}' into a decimal.");
                                     }
                                 }
 
@@ -1035,14 +1037,15 @@ namespace AplosConnector.Common.Services
                                         var allocationTagDefinition = dropdownTags.FirstOrDefault(t => t.Id.Equals(tagMapping.PexTagId, StringComparison.InvariantCultureIgnoreCase));
                                         var allocationTagOptionValue = allocationTag.Value?.ToString();
                                         var allocationTagOptionName = allocationTag.GetTagOptionName(allocationTagDefinition?.Options);
-                                        var allocationTagEntityId = aplosTags.FindMatchingEntity(allocationTagOptionValue, allocationTagOptionName, ':')?.Id;
-                                        if (allocationTagEntityId is null)
+                                        var allocationTagEntity = aplosTags.FindMatchingEntity(allocationTagOptionValue, allocationTagOptionName, ':');
+                                        if (allocationTagEntity is null)
                                         {
                                             log.LogWarning($"Could not match PEX tag '{allocationTagDefinition?.Name}' option ['{allocationTagOptionName}' : '{allocationTagOptionValue}'] with an Aplos tag entity.");
                                         }
                                         else
                                         {
-                                            pexTagValues.AplosTagIds.Add(allocationTagEntityId);
+                                            log.LogInformation($"Matched PEX tag '{allocationTagDefinition?.Name}' option ['{allocationTagOptionName}' : '{allocationTagOptionValue}'] with Aplos tag entity '{allocationTagEntity.Name}' ({allocationTagEntity.Id}).");
+                                            pexTagValues.AplosTagIds.Add(allocationTagEntity.Id);
                                         }
                                     }
                                 }
@@ -1052,6 +1055,7 @@ namespace AplosConnector.Common.Services
                             }
                             else
                             {
+                                log.LogInformation($"Business does not have tags, or tag are NOT enabled for the account. Using default fund id '{mapping.DefaultAplosFundId}' and default transaction account number '{mapping.DefaultAplosTransactionAccountNumber}'.");
                                 pexTagValues.AplosFundId = mapping.DefaultAplosFundId;
                                 pexTagValues.AplosTransactionAccountNumber = mapping.DefaultAplosTransactionAccountNumber;
                             }

--- a/src/AplosConnector.Common/Services/AplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/AplosIntegrationService.cs
@@ -956,10 +956,10 @@ namespace AplosConnector.Common.Services
                                 var allocationFundTag = allocation.GetTagValue(mapping.PexFundsTagId);
                                 if (allocationFundTag != null)
                                 {
-                                    var fundTagDefinition = dropdownTags.FirstOrDefault(t => t.Id.Equals(mapping.PexFundsTagId, StringComparison.InvariantCultureIgnoreCase));
+                                    var fundTagDefinition = dropdownTags.FirstOrDefault(t => t.Id.Equals(allocationFundTag.TagId, StringComparison.InvariantCultureIgnoreCase));
                                     var allocationFundTagOptionValue = allocationFundTag?.Value?.ToString();
                                     var allocationFundTagOptionName = allocationFundTag?.GetTagOptionName(fundTagDefinition?.Options);
-                                    var allocationFundEntity = aplosFunds.FindMatchingEntity(allocationFundTagOptionValue, allocationFundTagOptionName, ':');
+                                    var allocationFundEntity = aplosFunds.FindMatchingEntity(allocationFundTagOptionValue, allocationFundTagOptionName, ':', log);
                                     if (allocationFundEntity == null)
                                     {
                                         log.LogWarning($"Could not match PEX fund tag '{fundTagDefinition?.Name}' option ['{allocationFundTagOptionName}' : '{allocationFundTagOptionValue}'] with an Aplos fund entity.");
@@ -1001,10 +1001,10 @@ namespace AplosConnector.Common.Services
                                     break;
                                 }
 
-                                var expenseAccountTagDefinition = dropdownTags.FirstOrDefault(t => t.Id.Equals(expenseAccountTagId, StringComparison.InvariantCultureIgnoreCase));
+                                var expenseAccountTagDefinition = dropdownTags.FirstOrDefault(t => t.Id.Equals(expenseAccountTag.TagId, StringComparison.InvariantCultureIgnoreCase));
                                 var allocationExpenseAccountTagOptionName = expenseAccountTag.GetTagOptionName(expenseAccountTagDefinition?.Options);
                                 var allocationExpenseAccountTagOptionValue = expenseAccountTag.Value?.ToString();
-                                var allocationExpenseAccountEntity = aplosExpenseAccounts.FindMatchingEntity(allocationExpenseAccountTagOptionValue, allocationExpenseAccountTagOptionName, ':');
+                                var allocationExpenseAccountEntity = aplosExpenseAccounts.FindMatchingEntity(allocationExpenseAccountTagOptionValue, allocationExpenseAccountTagOptionName, ':', log);
                                 if (allocationExpenseAccountEntity == null)
                                 {
                                     log.LogWarning($"Could not match PEX expense account tag '{expenseAccountTagDefinition?.Name}' option ['{allocationExpenseAccountTagOptionName}' : '{allocationExpenseAccountTagOptionValue}'] with an Aplos expense account entity.");
@@ -1034,10 +1034,10 @@ namespace AplosConnector.Common.Services
                                             continue;
                                         }
 
-                                        var allocationTagDefinition = dropdownTags.FirstOrDefault(t => t.Id.Equals(tagMapping.PexTagId, StringComparison.InvariantCultureIgnoreCase));
+                                        var allocationTagDefinition = dropdownTags.FirstOrDefault(t => t.Id.Equals(allocationTag.TagId, StringComparison.InvariantCultureIgnoreCase));
                                         var allocationTagOptionValue = allocationTag.Value?.ToString();
                                         var allocationTagOptionName = allocationTag.GetTagOptionName(allocationTagDefinition?.Options);
-                                        var allocationTagEntity = aplosTags.FindMatchingEntity(allocationTagOptionValue, allocationTagOptionName, ':');
+                                        var allocationTagEntity = aplosTags.FindMatchingEntity(allocationTagOptionValue, allocationTagOptionName, ':', log);
                                         if (allocationTagEntity is null)
                                         {
                                             log.LogWarning($"Could not match PEX tag '{allocationTagDefinition?.Name}' option ['{allocationTagOptionName}' : '{allocationTagOptionValue}'] with an Aplos tag entity.");

--- a/src/AplosConnector.Common/Services/AplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/AplosIntegrationService.cs
@@ -960,7 +960,7 @@ namespace AplosConnector.Common.Services
                                 var allocationFundEntityId = aplosFunds.FindMatchingEntity(allocationFundTagOptionValue, allocationFundTagOptionName, ':')?.Id;
                                 if (allocationFundEntityId == null)
                                 {
-                                    log.LogWarning($"Could not match PEX expense account tag '{nameof(allocationFundTagOptionName)}' / '{allocationFundTagOptionValue}' with an Aplos fund.");
+                                    log.LogWarning($"Could not match PEX expense account tag '{nameof(allocationFundTagOptionName)}' / '{allocationFundTagOptionValue}' with an Aplos fund entity.");
                                 }
                                 else
                                 {
@@ -999,7 +999,7 @@ namespace AplosConnector.Common.Services
                                 var allocationExpenseAccountEntityId = aplosExpenseAccounts.FindMatchingEntity(allocationExpenseAccountTagOptionValue, allocationExpenseAccountTagOptionName, ':')?.Id;
                                 if (allocationExpenseAccountEntityId == null)
                                 {
-                                    log.LogWarning($"Could not match PEX expense account tag '{nameof(allocationExpenseAccountTagOptionName)}' / '{allocationExpenseAccountTagOptionValue}' with an Aplos expense account.");
+                                    log.LogWarning($"Could not match PEX expense account tag '{nameof(allocationExpenseAccountTagOptionName)}' / '{allocationExpenseAccountTagOptionValue}' with an Aplos expense account entity.");
                                 }
                                 else
                                 {
@@ -1031,7 +1031,7 @@ namespace AplosConnector.Common.Services
 
                                         if (allocationTagEntityId is null)
                                         {
-                                            log.LogWarning($"Could not match PEX tag '{nameof(allocationTagOptionName)}' / '{allocationTagOptionValue}' with an Aplos tag.");
+                                            log.LogWarning($"Could not match PEX tag '{nameof(allocationTagOptionName)}' / '{allocationTagOptionValue}' with an Aplos tag entity.");
                                         }
                                         else
                                         {

--- a/src/AplosConnector.Common/Services/AplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/AplosIntegrationService.cs
@@ -963,6 +963,10 @@ namespace AplosConnector.Common.Services
                                     {
                                         pexTagValues.AplosFundId = aplosFundId;
                                     }
+                                    else if (int.TryParse(aplosFunds.FindMatchingEntity(fundName, fundTransactionTag.Value.ToString(), ':')?.Id, out var aplosFundId2))
+                                    {
+                                        pexTagValues.AplosFundId = aplosFundId2;
+                                    }
                                 }
                                 else if (int.TryParse(fundTransactionTag?.Value.ToString(), out var aplosFundId))
                                 {
@@ -1002,7 +1006,7 @@ namespace AplosConnector.Common.Services
                                             StringComparison.InvariantCultureIgnoreCase))?.Options;
                                     var expenseAccountName = expenseAccountTag.GetTagOptionName(expenseAccountOptions);
                                     log.LogInformation($"Attempting to match expense account tag value {expenseAccountName} by name");
-                                    expenseAccountNumberTagValue = aplosExpenseAccounts.FindMatchingEntity(expenseAccountTag.Value.ToString(), expenseAccountName, ':')?.Id;
+                                    expenseAccountNumberTagValue = aplosExpenseAccounts.FindMatchingEntity(expenseAccountTag.Value.ToString(), expenseAccountName, ':')?.Id ?? aplosExpenseAccounts.FindMatchingEntity(expenseAccountName, expenseAccountTag.Value.ToString(), ':')?.Id;
                                 }
 
                                 if (decimal.TryParse(expenseAccountNumberTagValue, out decimal transactionAccountNumber))
@@ -1038,7 +1042,7 @@ namespace AplosConnector.Common.Services
                                                     StringComparison.InvariantCultureIgnoreCase))?.Options;
                                             var pexTagName = mappedTagValue.GetTagOptionName(pexTagOptions);
                                             log.LogInformation($"Attempting to match mapped tag value {pexTagName} by name");
-                                            aplosTagId = aplosTags.FindMatchingEntity(mappedTagValue.Value.ToString(), pexTagName, ':')?.Id;
+                                            aplosTagId = aplosTags.FindMatchingEntity(mappedTagValue.Value.ToString(), pexTagName, ':')?.Id ?? aplosTags.FindMatchingEntity(pexTagName, mappedTagValue.Value.ToString(), ':')?.Id;
                                         }
 
                                         pexTagValues.AplosTagIds.Add(aplosTagId);

--- a/src/AplosConnector.Common/Services/AplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/AplosIntegrationService.cs
@@ -960,7 +960,7 @@ namespace AplosConnector.Common.Services
                                 var allocationFundEntityId = aplosFunds.FindMatchingEntity(allocationFundTagOptionValue, allocationFundTagOptionName, ':')?.Id;
                                 if (allocationFundEntityId == null)
                                 {
-                                    log.LogWarning($"Could not match expense account tag '{nameof(allocationFundTagOptionName)}' / '{allocationFundTagOptionValue}' with an Aplos fund.");
+                                    log.LogWarning($"Could not match PEX expense account tag '{nameof(allocationFundTagOptionName)}' / '{allocationFundTagOptionValue}' with an Aplos fund.");
                                 }
                                 else
                                 {
@@ -999,7 +999,7 @@ namespace AplosConnector.Common.Services
                                 var allocationExpenseAccountEntityId = aplosExpenseAccounts.FindMatchingEntity(allocationExpenseAccountTagOptionValue, allocationExpenseAccountTagOptionName, ':')?.Id;
                                 if (allocationExpenseAccountEntityId == null)
                                 {
-                                    log.LogWarning($"Could not match expense account tag '{nameof(allocationExpenseAccountTagOptionName)}' / '{allocationExpenseAccountTagOptionValue}' with an Aplos expense account.");
+                                    log.LogWarning($"Could not match PEX expense account tag '{nameof(allocationExpenseAccountTagOptionName)}' / '{allocationExpenseAccountTagOptionValue}' with an Aplos expense account.");
                                 }
                                 else
                                 {

--- a/src/AplosConnector.Common/Services/AplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/AplosIntegrationService.cs
@@ -957,9 +957,8 @@ namespace AplosConnector.Common.Services
                                 if (allocationFundTag != null)
                                 {
                                     var fundTagDefinition = dropdownTags.FirstOrDefault(t => t.Id.Equals(mapping.PexFundsTagId, StringComparison.InvariantCultureIgnoreCase));
-                                    var fundTagOptions = fundTagDefinition?.Options;
                                     var allocationFundTagOptionValue = allocationFundTag?.Value?.ToString();
-                                    var allocationFundTagOptionName = allocationFundTag?.GetTagOptionName(fundTagOptions);
+                                    var allocationFundTagOptionName = allocationFundTag?.GetTagOptionName(fundTagDefinition?.Options);
                                     var allocationFundEntityId = aplosFunds.FindMatchingEntity(allocationFundTagOptionValue, allocationFundTagOptionName, ':')?.Id;
                                     if (allocationFundEntityId == null)
                                     {
@@ -998,8 +997,7 @@ namespace AplosConnector.Common.Services
                                 }
 
                                 var expenseAccountTagDefinition = dropdownTags.FirstOrDefault(t => t.Id.Equals(expenseAccountTagId, StringComparison.InvariantCultureIgnoreCase));
-                                var expenseAccountTagOptions = expenseAccountTagDefinition?.Options;
-                                var allocationExpenseAccountTagOptionName = expenseAccountTag.GetTagOptionName(expenseAccountTagOptions);
+                                var allocationExpenseAccountTagOptionName = expenseAccountTag.GetTagOptionName(expenseAccountTagDefinition?.Options);
                                 var allocationExpenseAccountTagOptionValue = expenseAccountTag.Value?.ToString();
                                 var allocationExpenseAccountEntityId = aplosExpenseAccounts.FindMatchingEntity(allocationExpenseAccountTagOptionValue, allocationExpenseAccountTagOptionName, ':')?.Id;
                                 if (allocationExpenseAccountEntityId == null)
@@ -1030,9 +1028,8 @@ namespace AplosConnector.Common.Services
                                         }
 
                                         var allocationTagDefinition = dropdownTags.FirstOrDefault(t => t.Id.Equals(tagMapping.PexTagId, StringComparison.InvariantCultureIgnoreCase));
-                                        var allocationTagOptions = allocationTagDefinition?.Options;
                                         var allocationTagOptionValue = allocationTag.Value?.ToString();
-                                        var allocationTagOptionName = allocationTag.GetTagOptionName(allocationTagOptions);
+                                        var allocationTagOptionName = allocationTag.GetTagOptionName(allocationTagDefinition?.Options);
                                         var allocationTagEntityId = aplosTags.FindMatchingEntity(allocationTag.Value.ToString(), allocationTagOptionName, ':')?.Id;
                                         if (allocationTagEntityId is null)
                                         {

--- a/src/AplosConnector.Common/Services/AplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/AplosIntegrationService.cs
@@ -1022,15 +1022,18 @@ namespace AplosConnector.Common.Services
                                     }
                                 }
 
-                                if (mapping.TagMappings != null)
+                                if (mapping.TagMappings?.Any() == true)
                                 {
                                     pexTagValues.AplosTagIds = new List<string>();
+
+                                    log.LogInformation($"Processing {mapping.TagMappings.Length} Aplos tag mappings for transaction {transaction.TransactionId} allocation {allocation.Amount:C}");
+
                                     foreach (var tagMapping in mapping.TagMappings)
                                     {
                                         var allocationTag = allocation.GetTagValue(tagMapping.PexTagId);
                                         if (allocationTag == null || allocationTag.TagId == mapping.PexTaxTagId)
                                         {
-                                            log.LogInformation($"No PEX tag {tagMapping.PexTagId} on allocation {allocation.Amount:C}");
+                                            log.LogInformation($"No PEX tag {tagMapping.PexTagId} on transaction {transaction.TransactionId} allocation {allocation.Amount:C}");
                                             continue;
                                         }
 
@@ -1048,6 +1051,10 @@ namespace AplosConnector.Common.Services
                                             pexTagValues.AplosTagIds.Add(allocationTagEntity.Id);
                                         }
                                     }
+                                }
+                                else
+                                {
+                                    log.LogInformation($"No Aplos tag mappings to process.");
                                 }
 
                                 var taxTag = allocation.GetTagValue(mapping.PexTaxTagId);
@@ -1113,7 +1120,7 @@ namespace AplosConnector.Common.Services
                         }
                         else if (transactionSyncResult == TransactionSyncResult.Failed)
                         {
-                            log.LogWarning ($"Failed to sync transaction {transaction.TransactionId}");
+                            log.LogWarning($"Failed to sync transaction {transaction.TransactionId}");
                             failureCount++;
                         }
                     }

--- a/src/AplosConnector.Common/Services/AplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/AplosIntegrationService.cs
@@ -959,7 +959,7 @@ namespace AplosConnector.Common.Services
                                     var fundOptions = dropdownTags.FirstOrDefault(t =>
                                         t.Id.Equals(mapping.PexFundsTagId, StringComparison.InvariantCultureIgnoreCase))?.Options;
                                     var fundName = fundTransactionTag?.GetTagOptionName(fundOptions);
-                                    if (int.TryParse(aplosFunds.MatchEntityByName(fundName)?.Id, out var aplosFundId))
+                                    if (int.TryParse(aplosFunds.FindMatchingEntity(fundTransactionTag.Value.ToString(), fundName, ':')?.Id, out var aplosFundId))
                                     {
                                         pexTagValues.AplosFundId = aplosFundId;
                                     }
@@ -1002,7 +1002,7 @@ namespace AplosConnector.Common.Services
                                             StringComparison.InvariantCultureIgnoreCase))?.Options;
                                     var expenseAccountName = expenseAccountTag.GetTagOptionName(expenseAccountOptions);
                                     log.LogInformation($"Attempting to match expense account tag value {expenseAccountName} by name");
-                                    expenseAccountNumberTagValue = aplosExpenseAccounts.MatchEntityByName(expenseAccountName, ':')?.Id;
+                                    expenseAccountNumberTagValue = aplosExpenseAccounts.FindMatchingEntity(expenseAccountTag.Value.ToString(), expenseAccountName, ':')?.Id;
                                 }
 
                                 if (decimal.TryParse(expenseAccountNumberTagValue, out decimal transactionAccountNumber))
@@ -1038,7 +1038,7 @@ namespace AplosConnector.Common.Services
                                                     StringComparison.InvariantCultureIgnoreCase))?.Options;
                                             var pexTagName = mappedTagValue.GetTagOptionName(pexTagOptions);
                                             log.LogInformation($"Attempting to match mapped tag value {pexTagName} by name");
-                                            aplosTagId = aplosTags.MatchEntityByName(pexTagName, ':')?.Id;
+                                            aplosTagId = aplosTags.FindMatchingEntity(mappedTagValue.Value.ToString(), pexTagName, ':')?.Id;
                                         }
 
                                         pexTagValues.AplosTagIds.Add(aplosTagId);

--- a/src/AplosConnector.Common/Services/AplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/AplosIntegrationService.cs
@@ -1081,7 +1081,7 @@ namespace AplosConnector.Common.Services
                             continue;
                         }
 
-                        log.LogDebug($"Starting sync for transaction {transaction.TransactionId}");
+                        log.LogInformation($"Starting sync for transaction {transaction.TransactionId}");
 
                         var transactionSyncResult = TransactionSyncResult.Failed;
                         try

--- a/src/AplosConnector.Common/Services/AplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/AplosIntegrationService.cs
@@ -963,7 +963,7 @@ namespace AplosConnector.Common.Services
                                     {
                                         pexTagValues.AplosFundId = aplosFundId;
                                     }
-                                    else if (int.TryParse(aplosFunds.FindMatchingEntity(fundName, fundTransactionTag.Value.ToString(), ':')?.Id, out var aplosFundId2))
+                                    else if (int.TryParse(aplosFunds.FindMatchingEntity(fundName, fundName, ':')?.Id, out var aplosFundId2))
                                     {
                                         pexTagValues.AplosFundId = aplosFundId2;
                                     }
@@ -1006,7 +1006,7 @@ namespace AplosConnector.Common.Services
                                             StringComparison.InvariantCultureIgnoreCase))?.Options;
                                     var expenseAccountName = expenseAccountTag.GetTagOptionName(expenseAccountOptions);
                                     log.LogInformation($"Attempting to match expense account tag value {expenseAccountName} by name");
-                                    expenseAccountNumberTagValue = aplosExpenseAccounts.FindMatchingEntity(expenseAccountTag.Value.ToString(), expenseAccountName, ':')?.Id ?? aplosExpenseAccounts.FindMatchingEntity(expenseAccountName, expenseAccountTag.Value.ToString(), ':')?.Id;
+                                    expenseAccountNumberTagValue = aplosExpenseAccounts.FindMatchingEntity(expenseAccountTag.Value.ToString(), expenseAccountName, ':')?.Id ?? aplosExpenseAccounts.FindMatchingEntity(expenseAccountName, expenseAccountName, ':')?.Id;
                                 }
 
                                 if (decimal.TryParse(expenseAccountNumberTagValue, out decimal transactionAccountNumber))
@@ -1042,7 +1042,7 @@ namespace AplosConnector.Common.Services
                                                     StringComparison.InvariantCultureIgnoreCase))?.Options;
                                             var pexTagName = mappedTagValue.GetTagOptionName(pexTagOptions);
                                             log.LogInformation($"Attempting to match mapped tag value {pexTagName} by name");
-                                            aplosTagId = aplosTags.FindMatchingEntity(mappedTagValue.Value.ToString(), pexTagName, ':')?.Id ?? aplosTags.FindMatchingEntity(pexTagName, mappedTagValue.Value.ToString(), ':')?.Id;
+                                            aplosTagId = aplosTags.FindMatchingEntity(mappedTagValue.Value.ToString(), pexTagName, ':')?.Id ?? aplosTags.FindMatchingEntity(pexTagName, pexTagName, ':')?.Id;
                                         }
 
                                         pexTagValues.AplosTagIds.Add(aplosTagId);

--- a/src/AplosConnector.Common/Services/AplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/AplosIntegrationService.cs
@@ -953,24 +953,28 @@ namespace AplosConnector.Common.Services
 
                             if (useTags)
                             {
-                                var fundTagOptions = dropdownTags.FirstOrDefault(t => t.Id.Equals(mapping.PexFundsTagId, StringComparison.InvariantCultureIgnoreCase))?.Options;
                                 var allocationFundTag = allocation.GetTagValue(mapping.PexFundsTagId);
-                                var allocationFundTagOptionValue = allocationFundTag?.Value?.ToString();
-                                var allocationFundTagOptionName = allocationFundTag?.GetTagOptionName(fundTagOptions);
-                                var allocationFundEntityId = aplosFunds.FindMatchingEntity(allocationFundTagOptionValue, allocationFundTagOptionName, ':')?.Id;
-                                if (allocationFundEntityId == null)
+                                if (allocationFundTag != null)
                                 {
-                                    log.LogWarning($"Could not match PEX expense account tag option '{nameof(allocationFundTagOptionName)}' / '{allocationFundTagOptionValue}' with an Aplos fund entity.");
-                                }
-                                else
-                                {
-                                    if (int.TryParse(allocationFundEntityId, out var aplosFundId))
+                                    var fundTagDefinition = dropdownTags.FirstOrDefault(t => t.Id.Equals(mapping.PexFundsTagId, StringComparison.InvariantCultureIgnoreCase));
+                                    var fundTagOptions = fundTagDefinition?.Options;
+                                    var allocationFundTagOptionValue = allocationFundTag?.Value?.ToString();
+                                    var allocationFundTagOptionName = allocationFundTag?.GetTagOptionName(fundTagOptions);
+                                    var allocationFundEntityId = aplosFunds.FindMatchingEntity(allocationFundTagOptionValue, allocationFundTagOptionName, ':')?.Id;
+                                    if (allocationFundEntityId == null)
                                     {
-                                        pexTagValues.AplosFundId = aplosFundId;
+                                        log.LogWarning($"Could not match PEX fund tag '{fundTagDefinition?.Name}' option ['{allocationFundTagOptionName}' : '{allocationFundTagOptionValue}'] with an Aplos fund entity.");
                                     }
                                     else
                                     {
-                                        log.LogWarning($"Could not parse Aplos expense fund id '{allocationFundEntityId}' into a int.");
+                                        if (int.TryParse(allocationFundEntityId, out var aplosFundId))
+                                        {
+                                            pexTagValues.AplosFundId = aplosFundId;
+                                        }
+                                        else
+                                        {
+                                            log.LogWarning($"Could not parse Aplos expense fund id '{allocationFundEntityId}' into a int.");
+                                        }
                                     }
                                 }
 
@@ -993,13 +997,14 @@ namespace AplosConnector.Common.Services
                                     break;
                                 }
 
-                                var expenseAccountTagOptions = dropdownTags.FirstOrDefault(t => t.Id.Equals(expenseAccountTagId, StringComparison.InvariantCultureIgnoreCase))?.Options;
+                                var expenseAccountTagDefinition = dropdownTags.FirstOrDefault(t => t.Id.Equals(expenseAccountTagId, StringComparison.InvariantCultureIgnoreCase));
+                                var expenseAccountTagOptions = expenseAccountTagDefinition?.Options;
                                 var allocationExpenseAccountTagOptionName = expenseAccountTag.GetTagOptionName(expenseAccountTagOptions);
                                 var allocationExpenseAccountTagOptionValue = expenseAccountTag.Value.ToString();
                                 var allocationExpenseAccountEntityId = aplosExpenseAccounts.FindMatchingEntity(allocationExpenseAccountTagOptionValue, allocationExpenseAccountTagOptionName, ':')?.Id;
                                 if (allocationExpenseAccountEntityId == null)
                                 {
-                                    log.LogWarning($"Could not match PEX expense account tag option '{nameof(allocationExpenseAccountTagOptionName)}' / '{allocationExpenseAccountTagOptionValue}' with an Aplos expense account entity.");
+                                    log.LogWarning($"Could not match PEX expense account tag '{expenseAccountTagDefinition?.Name}' option ['{allocationExpenseAccountTagOptionName}' : '{allocationExpenseAccountTagOptionValue}'] with an Aplos expense account entity.");
                                 }
                                 else
                                 {
@@ -1024,14 +1029,14 @@ namespace AplosConnector.Common.Services
                                             continue;
                                         }
 
-                                        var allocationTagOptions = dropdownTags.FirstOrDefault(t => t.Id.Equals(tagMapping.PexTagId, StringComparison.InvariantCultureIgnoreCase))?.Options;
+                                        var allocationTagDefinition = dropdownTags.FirstOrDefault(t => t.Id.Equals(tagMapping.PexTagId, StringComparison.InvariantCultureIgnoreCase));
+                                        var allocationTagOptions = allocationTagDefinition?.Options;
                                         var allocationTagOptionValue = allocationTag.Value.ToString();
                                         var allocationTagOptionName = allocationTag.GetTagOptionName(allocationTagOptions);
                                         var allocationTagEntityId = aplosTags.FindMatchingEntity(allocationTag.Value.ToString(), allocationTagOptionName, ':')?.Id;
-
                                         if (allocationTagEntityId is null)
                                         {
-                                            log.LogWarning($"Could not match PEX tag option '{nameof(allocationTagOptionName)}' / '{allocationTagOptionValue}' with an Aplos tag entity.");
+                                            log.LogWarning($"Could not match PEX tag '{allocationTagDefinition?.Name}' option ['{allocationTagOptionName}' : '{allocationTagOptionValue}'] with an Aplos tag entity.");
                                         }
                                         else
                                         {

--- a/src/AplosConnector.Common/Services/AplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/AplosIntegrationService.cs
@@ -963,9 +963,13 @@ namespace AplosConnector.Common.Services
                                     {
                                         pexTagValues.AplosFundId = aplosFundId;
                                     }
-                                    else if (int.TryParse(aplosFunds.FindMatchingEntity(fundName, fundName, ':')?.Id, out var aplosFundId2))
+                                    else if (int.TryParse(aplosFunds.MatchEntityByName(fundTransactionTag.Value.ToString(), ':')?.Id, out var aplosFundId2))
                                     {
                                         pexTagValues.AplosFundId = aplosFundId2;
+                                    }
+                                    else if (int.TryParse(aplosFunds.MatchEntityByName(fundName, ':')?.Id, out var aplosFundId3))
+                                    {
+                                        pexTagValues.AplosFundId = aplosFundId3;
                                     }
                                 }
                                 else if (int.TryParse(fundTransactionTag?.Value.ToString(), out var aplosFundId))
@@ -1006,7 +1010,7 @@ namespace AplosConnector.Common.Services
                                             StringComparison.InvariantCultureIgnoreCase))?.Options;
                                     var expenseAccountName = expenseAccountTag.GetTagOptionName(expenseAccountOptions);
                                     log.LogInformation($"Attempting to match expense account tag value {expenseAccountName} by name");
-                                    expenseAccountNumberTagValue = aplosExpenseAccounts.FindMatchingEntity(expenseAccountTag.Value.ToString(), expenseAccountName, ':')?.Id ?? aplosExpenseAccounts.FindMatchingEntity(expenseAccountName, expenseAccountName, ':')?.Id;
+                                    expenseAccountNumberTagValue = aplosExpenseAccounts.FindMatchingEntity(expenseAccountTag.Value.ToString(), expenseAccountName, ':')?.Id ?? aplosExpenseAccounts.MatchEntityByName(expenseAccountTag.Value.ToString(), ':')?.Id ?? aplosExpenseAccounts.MatchEntityByName(expenseAccountName, ':')?.Id;
                                 }
 
                                 if (decimal.TryParse(expenseAccountNumberTagValue, out decimal transactionAccountNumber))
@@ -1042,7 +1046,7 @@ namespace AplosConnector.Common.Services
                                                     StringComparison.InvariantCultureIgnoreCase))?.Options;
                                             var pexTagName = mappedTagValue.GetTagOptionName(pexTagOptions);
                                             log.LogInformation($"Attempting to match mapped tag value {pexTagName} by name");
-                                            aplosTagId = aplosTags.FindMatchingEntity(mappedTagValue.Value.ToString(), pexTagName, ':')?.Id ?? aplosTags.FindMatchingEntity(pexTagName, pexTagName, ':')?.Id;
+                                            aplosTagId = aplosTags.FindMatchingEntity(mappedTagValue.Value.ToString(), pexTagName, ':')?.Id ?? aplosTags.MatchEntityByName(mappedTagValue.Value.ToString(), ':')?.Id ?? aplosTags.MatchEntityByName(pexTagName, ':')?.Id;
                                         }
 
                                         pexTagValues.AplosTagIds.Add(aplosTagId);

--- a/src/AplosConnector.Common/Services/AplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/AplosIntegrationService.cs
@@ -1000,7 +1000,7 @@ namespace AplosConnector.Common.Services
                                 var expenseAccountTagDefinition = dropdownTags.FirstOrDefault(t => t.Id.Equals(expenseAccountTagId, StringComparison.InvariantCultureIgnoreCase));
                                 var expenseAccountTagOptions = expenseAccountTagDefinition?.Options;
                                 var allocationExpenseAccountTagOptionName = expenseAccountTag.GetTagOptionName(expenseAccountTagOptions);
-                                var allocationExpenseAccountTagOptionValue = expenseAccountTag.Value.ToString();
+                                var allocationExpenseAccountTagOptionValue = expenseAccountTag.Value?.ToString();
                                 var allocationExpenseAccountEntityId = aplosExpenseAccounts.FindMatchingEntity(allocationExpenseAccountTagOptionValue, allocationExpenseAccountTagOptionName, ':')?.Id;
                                 if (allocationExpenseAccountEntityId == null)
                                 {
@@ -1031,7 +1031,7 @@ namespace AplosConnector.Common.Services
 
                                         var allocationTagDefinition = dropdownTags.FirstOrDefault(t => t.Id.Equals(tagMapping.PexTagId, StringComparison.InvariantCultureIgnoreCase));
                                         var allocationTagOptions = allocationTagDefinition?.Options;
-                                        var allocationTagOptionValue = allocationTag.Value.ToString();
+                                        var allocationTagOptionValue = allocationTag.Value?.ToString();
                                         var allocationTagOptionName = allocationTag.GetTagOptionName(allocationTagOptions);
                                         var allocationTagEntityId = aplosTags.FindMatchingEntity(allocationTag.Value.ToString(), allocationTagOptionName, ':')?.Id;
                                         if (allocationTagEntityId is null)

--- a/src/AplosConnector.Common/Services/AplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/AplosIntegrationService.cs
@@ -1081,7 +1081,7 @@ namespace AplosConnector.Common.Services
                             continue;
                         }
 
-                        log.LogInformation($"Starting sync for transaction {transaction.TransactionId}");
+                        log.LogDebug($"Starting sync for transaction {transaction.TransactionId}");
 
                         var transactionSyncResult = TransactionSyncResult.Failed;
                         try
@@ -1101,18 +1101,19 @@ namespace AplosConnector.Common.Services
 
                         if (transactionSyncResult != TransactionSyncResult.NotEligible)
                         {
+                            log.LogWarning($"Sync not eligible for transaction {transaction.TransactionId}");
                             eligibleCount++;
                         }
                         if (transactionSyncResult == TransactionSyncResult.Success)
                         {
                             syncCount++;
-                            log.LogInformation($"Synced transaction {transaction.TransactionId} with Aplos");
-                            var syncedNoteText =
-                                $"{PexCardConst.SyncedWithAplosNote} on {DateTime.UtcNow.ToEst():MM/dd/yyyy h:mm tt}";
+                            log.LogInformation($"Synced transaction {transaction.TransactionId}");
+                            var syncedNoteText = $"{PexCardConst.SyncedWithAplosNote} on {DateTime.UtcNow.ToEst():MM/dd/yyyy h:mm tt}";
                             await _pexApiClient.AddTransactionNote(mapping.PEXExternalAPIToken, transaction, syncedNoteText);
                         }
                         else if (transactionSyncResult == TransactionSyncResult.Failed)
                         {
+                            log.LogWarning ($"Failed to sync transaction {transaction.TransactionId}");
                             failureCount++;
                         }
                     }

--- a/src/AplosConnector.Common/Services/AplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/AplosIntegrationService.cs
@@ -967,10 +967,6 @@ namespace AplosConnector.Common.Services
                                     {
                                         pexTagValues.AplosFundId = aplosFundId2;
                                     }
-                                    else if (int.TryParse(aplosFunds.MatchEntityByName(fundName, ':')?.Id, out var aplosFundId3))
-                                    {
-                                        pexTagValues.AplosFundId = aplosFundId3;
-                                    }
                                 }
                                 else if (int.TryParse(fundTransactionTag?.Value.ToString(), out var aplosFundId))
                                 {
@@ -1010,7 +1006,7 @@ namespace AplosConnector.Common.Services
                                             StringComparison.InvariantCultureIgnoreCase))?.Options;
                                     var expenseAccountName = expenseAccountTag.GetTagOptionName(expenseAccountOptions);
                                     log.LogInformation($"Attempting to match expense account tag value {expenseAccountName} by name");
-                                    expenseAccountNumberTagValue = aplosExpenseAccounts.FindMatchingEntity(expenseAccountTag.Value.ToString(), expenseAccountName, ':')?.Id ?? aplosExpenseAccounts.MatchEntityByName(expenseAccountTag.Value.ToString(), ':')?.Id ?? aplosExpenseAccounts.MatchEntityByName(expenseAccountName, ':')?.Id;
+                                    expenseAccountNumberTagValue = aplosExpenseAccounts.FindMatchingEntity(expenseAccountTag.Value.ToString(), expenseAccountName, ':')?.Id ?? aplosExpenseAccounts.MatchEntityByName(expenseAccountTag.Value.ToString(), ':')?.Id;
                                 }
 
                                 if (decimal.TryParse(expenseAccountNumberTagValue, out decimal transactionAccountNumber))
@@ -1046,7 +1042,7 @@ namespace AplosConnector.Common.Services
                                                     StringComparison.InvariantCultureIgnoreCase))?.Options;
                                             var pexTagName = mappedTagValue.GetTagOptionName(pexTagOptions);
                                             log.LogInformation($"Attempting to match mapped tag value {pexTagName} by name");
-                                            aplosTagId = aplosTags.FindMatchingEntity(mappedTagValue.Value.ToString(), pexTagName, ':')?.Id ?? aplosTags.MatchEntityByName(mappedTagValue.Value.ToString(), ':')?.Id ?? aplosTags.MatchEntityByName(pexTagName, ':')?.Id;
+                                            aplosTagId = aplosTags.FindMatchingEntity(mappedTagValue.Value.ToString(), pexTagName, ':')?.Id ?? aplosTags.MatchEntityByName(mappedTagValue.Value.ToString(), ':')?.Id;
                                         }
 
                                         pexTagValues.AplosTagIds.Add(aplosTagId);

--- a/src/AplosConnector.SyncWorker/AplosConnector.SyncWorker.csproj
+++ b/src/AplosConnector.SyncWorker/AplosConnector.SyncWorker.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="3.1.13" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.11" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="PexCard.Api.Client" Version="1.26.0" />
+    <PackageReference Include="PexCard.Api.Client" Version="1.30.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Aplos.Api.Client\Aplos.Api.Client.csproj" />

--- a/src/AplosConnector.Web/AplosConnector.Web.csproj
+++ b/src/AplosConnector.Web/AplosConnector.Web.csproj
@@ -41,9 +41,9 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.13" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="3.1.13" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.5" />
-    <PackageReference Include="PexCard.Api.Client" Version="1.26.0" />
+    <PackageReference Include="PexCard.Api.Client" Version="1.30.0" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.1.13" />
-    <PackageReference Include="PexCard.Api.Client.Core" Version="1.26.0" />
+    <PackageReference Include="PexCard.Api.Client.Core" Version="1.30.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
[AB#58278](https://pexcard.visualstudio.com/1e893f43-a87f-46d1-abc4-e68d9e66c1ef/_workitems/edit/58278)

As an Aplos user, I want my transactions to use my tags by matching with the correct Aplos entity id in the tag option value, or by matching the correct Aplos entity name from the tag option value **OR** tag option name.