### PR TITLE
63136 "Automatically import PEX transfers into Aplos" toggle is missing for prepaid businesses

### DIFF
--- a/src/AplosConnector.Web/ClientApp/src/app/connect/connect.component.html
+++ b/src/AplosConnector.Web/ClientApp/src/app/connect/connect.component.html
@@ -218,7 +218,7 @@
           type="checkbox"
           clrToggle
           name="syncTransfers"
-          [(ngM odel)]="settingsModel.syncTransfers"
+          [(ngModel)]="settingsModel.syncTransfers"
           />
         <label>Automatically import PEX transfers into Aplos.</label>
       </clr-toggle-wrapper>

--- a/src/AplosConnector.Web/ClientApp/src/app/manage-connections/manage-connections.component.html
+++ b/src/AplosConnector.Web/ClientApp/src/app/manage-connections/manage-connections.component.html
@@ -259,19 +259,19 @@
         </tr>
       </table>
 
-      <table class="table table-vertical" *ngIf="settings.syncTransfers || settingsModel.syncInvoices || settings.syncPexFees">
+      <table class="table table-vertical" *ngIf="settings.syncTransfers || settings.syncInvoices || settings.syncPexFees">
         <tbody>
-          <tr class="left" *ngIf="settings.syncTransfers || settingsModel.syncInvoices && transferContact">
+          <tr class="left" *ngIf="settings.syncTransfers || settings.syncInvoices && transferContact">
             <th *ngIf="isPrepaid()">Contact for transfers</th>
             <th *ngIf="isCredit()">Contact for bill payments</th>
             <td>{{transferContact.name}}</td>
           </tr>
-          <tr class="left" *ngIf="settings.syncTransfers || settingsModel.syncInvoices && transferFund">
+          <tr class="left" *ngIf="settings.syncTransfers || settings.syncInvoices && transferFund">
             <th *ngIf="isPrepaid()">Fund for transfers</th>
             <th *ngIf="isCredit()">Fund for bill payments</th>
             <td>{{transferFund.name}}</td>
           </tr>
-          <tr class="left" *ngIf="settings.syncTransfers || settingsModel.syncInvoices && transferAccount">
+          <tr class="left" *ngIf="settings.syncTransfers || settings.syncInvoices && transferAccount">
             <th *ngIf="isPrepaid()">Transaction account for transfers</th>
             <th *ngIf="isCredit()">Transaction account for bill payments</th>
             <td>{{transferAccount | aplosAccount}}</td>


### PR DESCRIPTION
[AB#63136](https://pexcard.visualstudio.com/Marketplace/_workitems/edit/63136/)
[AB#63065](https://pexcard.visualstudio.com/Marketplace/_workitems/edit/63065/)