### PR TITLE
87446 Aplos: default tags values are not pulled into "Default" dropdown (package fix)

### DIFF
--- a/src/AplosConnector.Common/AplosConnector.Common.csproj
+++ b/src/AplosConnector.Common/AplosConnector.Common.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="6.0.27" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.2.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="PexCard.Api.Client.Core" Version="1.64.0" />
+    <PackageReference Include="PexCard.Api.Client.Core" Version="1.62.0" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.0" />
     <PackageReference Include="Polly" Version="8.3.0" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />

--- a/src/AplosConnector.SyncWorker/AplosConnector.SyncWorker.csproj
+++ b/src/AplosConnector.SyncWorker/AplosConnector.SyncWorker.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.2.2" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="PexCard.Api.Client" Version="1.64.0" />
+    <PackageReference Include="PexCard.Api.Client" Version="1.62.0" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.0" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>

--- a/src/AplosConnector.Web/AplosConnector.Web.csproj
+++ b/src/AplosConnector.Web/AplosConnector.Web.csproj
@@ -35,9 +35,9 @@
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.AzureStorage" Version="3.1.24" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="6.0.27" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.27" />
-    <PackageReference Include="PexCard.Api.Client" Version="1.64.0" />
+    <PackageReference Include="PexCard.Api.Client" Version="1.62.0" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="6.0.27" />
-    <PackageReference Include="PexCard.Api.Client.Core" Version="1.64.0" />
+    <PackageReference Include="PexCard.Api.Client.Core" Version="1.62.0" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.0" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.0" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />


### PR DESCRIPTION
[AB#87605](https://pexcard.visualstudio.com/Marketplace/_workitems/edit/87605/)