### PR TITLE
Remove setting extra setting of IsManualSync = false

### DIFF
--- a/src/AplosConnector.Common/Storage/Pex2AplosMappingStorage.cs
+++ b/src/AplosConnector.Common/Storage/Pex2AplosMappingStorage.cs
@@ -55,8 +55,6 @@ namespace AplosConnector.Common.Storage
 
         public async Task UpdateAsync(Pex2AplosMappingModel model, CancellationToken cancellationToken)
         {
-            model.IsManualSync = false; // always reset to false when saving
-
             var entity = _storageMappingService.Map(model);
             entity.PartitionKey = PARTITION_KEY;
             entity.RowKey = model.PEXBusinessAcctId.ToString();


### PR DESCRIPTION
It's already done in the mapping below when saving, and it causes the rest of the sync to think it's not a manual sync.

[AB#94899](https://pexcard.visualstudio.com/1e893f43-a87f-46d1-abc4-e68d9e66c1ef/_workitems/edit/94899)