### PR TITLE
139243 Aplos: Fix false-positive sync check in WasPexTransactionSyncedToAplos

### DIFF
--- a/src/AplosConnector.Common/Services/AplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/AplosIntegrationService.cs
@@ -2296,9 +2296,28 @@ namespace AplosConnector.Common.Services
         public bool WasPexTransactionSyncedToAplos(IEnumerable<AplosApiTransactionDetail> aplosTransactions, string pexTransactionId)
         {
             return aplosTransactions.Any(aplosTransaction =>
-                (!string.IsNullOrEmpty(aplosTransaction.Note) && (aplosTransaction.Note.StartsWith(pexTransactionId) || aplosTransaction.Note.EndsWith(pexTransactionId)))
-                ||
-                (!string.IsNullOrEmpty(aplosTransaction.Memo) && (aplosTransaction.Memo.StartsWith(pexTransactionId) || aplosTransaction.Memo.EndsWith(pexTransactionId))));
+                NoteOrMemoMatchesPexTransactionId(aplosTransaction.Note, pexTransactionId)
+                || NoteOrMemoMatchesPexTransactionId(aplosTransaction.Memo, pexTransactionId));
+        }
+
+        // The Aplos Note/Memo is built as a " | "-delimited string. Depending on the sync path and
+        // history the PEX id can appear as the whole value (invoices), as the last segment in the new
+        // format "{ContactName} | {Notes} | {TransactionId}", or as the first segment in the legacy
+        // format "{TransactionId} | {Name}". Matching must be delimiter-aware so that a cardholder
+        // TransactionId like 12489828 does NOT make a bare StartsWith/EndsWith collide with an
+        // unrelated invoice id such as 89828 and flag it as already synced (work item 138157).
+        private static bool NoteOrMemoMatchesPexTransactionId(string noteOrMemo, string pexTransactionId)
+        {
+            if (string.IsNullOrEmpty(noteOrMemo) || string.IsNullOrEmpty(pexTransactionId))
+            {
+                return false;
+            }
+
+            const string separator = " | ";
+
+            return noteOrMemo == pexTransactionId
+                || noteOrMemo.EndsWith(separator + pexTransactionId)
+                || noteOrMemo.StartsWith(pexTransactionId + separator);
         }
 
         private readonly ConcurrentDictionary<int, CardholderDetailsModel> _cardholderDetailsCache =

--- a/tests/AplosConnector.Common.Tests/AplosIntegrationServiceTests.cs
+++ b/tests/AplosConnector.Common.Tests/AplosIntegrationServiceTests.cs
@@ -510,6 +510,126 @@ namespace AplosConnector.Common.Tests
         }
 
         [Fact]
+        public void WasPexTransactionSyncedToAplos_ReturnsTrue_WhenIdIsLastSegmentOfNote()
+        {
+            //Arrange - new note format "{ContactName} | {Notes} | {TransactionId}"
+            string pexTransactionId = "12489828";
+
+            var aplosTransactions = new List<AplosApiTransactionDetail>
+            {
+                new AplosApiTransactionDetail
+                {
+                    Note = $"John Doe | Office supplies | {pexTransactionId}",
+                },
+            };
+
+            AplosIntegrationService service = GetAplosIntegrationService();
+
+            //Act
+            bool wasSynced = service.WasPexTransactionSyncedToAplos(aplosTransactions, pexTransactionId);
+
+            //Assert
+            Assert.True(wasSynced);
+        }
+
+        [Fact]
+        public void WasPexTransactionSyncedToAplos_ReturnsTrue_WhenIdIsFirstSegmentOfNote()
+        {
+            //Arrange - legacy note format "{TransactionId} | {Name}"
+            string pexTransactionId = "12489828";
+
+            var aplosTransactions = new List<AplosApiTransactionDetail>
+            {
+                new AplosApiTransactionDetail
+                {
+                    Note = $"{pexTransactionId} | John Doe",
+                },
+            };
+
+            AplosIntegrationService service = GetAplosIntegrationService();
+
+            //Act
+            bool wasSynced = service.WasPexTransactionSyncedToAplos(aplosTransactions, pexTransactionId);
+
+            //Assert
+            Assert.True(wasSynced);
+        }
+
+        [Fact]
+        public void WasPexTransactionSyncedToAplos_ReturnsTrue_WhenIdIsLastSegmentOfMemo()
+        {
+            //Arrange - same delimiter-aware handling must apply to Memo
+            string pexTransactionId = "12489828";
+
+            var aplosTransactions = new List<AplosApiTransactionDetail>
+            {
+                new AplosApiTransactionDetail
+                {
+                    Memo = $"John Doe | Office supplies | {pexTransactionId}",
+                },
+            };
+
+            AplosIntegrationService service = GetAplosIntegrationService();
+
+            //Act
+            bool wasSynced = service.WasPexTransactionSyncedToAplos(aplosTransactions, pexTransactionId);
+
+            //Assert
+            Assert.True(wasSynced);
+        }
+
+        [Fact]
+        public void WasPexTransactionSyncedToAplos_ReturnsFalse_WhenInvoiceIdIsSubstringOfCardholderTransactionId()
+        {
+            //Arrange - invoice 89828 must NOT match a cardholder transaction whose Note ends with
+            //TransactionId 12489828 (the bug in work item 138157).
+            string invoiceId = "89828";
+
+            var aplosTransactions = new List<AplosApiTransactionDetail>
+            {
+                new AplosApiTransactionDetail
+                {
+                    Note = "John Doe | Office supplies | 12489828",
+                },
+                new AplosApiTransactionDetail
+                {
+                    Memo = "John Doe | Office supplies | 12489828",
+                },
+            };
+
+            AplosIntegrationService service = GetAplosIntegrationService();
+
+            //Act
+            bool wasSynced = service.WasPexTransactionSyncedToAplos(aplosTransactions, invoiceId);
+
+            //Assert
+            Assert.False(wasSynced);
+        }
+
+        [Fact]
+        public void WasPexTransactionSyncedToAplos_ReturnsTrue_WhenInvoiceIdIsExactNote()
+        {
+            //Arrange - invoices are synced with Note set to the bare invoice id
+            string invoiceId = "89828";
+
+            var aplosTransactions = new List<AplosApiTransactionDetail>
+            {
+                new AplosApiTransactionDetail
+                {
+                    Note = invoiceId,
+                },
+            };
+
+            AplosIntegrationService service = GetAplosIntegrationService();
+
+            //Act
+            bool wasSynced = service.WasPexTransactionSyncedToAplos(aplosTransactions, invoiceId);
+
+            //Assert
+            Assert.True(wasSynced);
+        }
+
+        [Fact]
         public void DedupeAplosAccounts_ReturnsUniqueAccounts_WhenThreeDupesExist()
         {
             //Arrange


### PR DESCRIPTION
[AB#138157](https://pexcard.visualstudio.com/PEX%20Processing%20Solution/_workitems/edit/138157)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pexcard/pex-connector-aplos/pull/258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->