### PR TITLE
pex-connector-aplos: Add reimbursement configuration fields to data model

### DIFF
--- a/src/AplosConnector.Common/Entities/Pex2AplosMappingEntity.cs
+++ b/src/AplosConnector.Common/Entities/Pex2AplosMappingEntity.cs
@@ -30,6 +30,7 @@ namespace AplosConnector.Common.Entities
         public bool SyncInvoices { get; set; }
         public bool SyncPexFees { get; set; }
         public bool SyncRebates { get; set; }
+        public bool SyncReimbursements { get; set; }
         public bool SyncApprovedOnly { get; set; }
         public DateTime EarliestTransactionDateToSync { get; set; }
         public DateTime? EndDateUtc { get; set; }
@@ -68,12 +69,19 @@ namespace AplosConnector.Common.Entities
         public int PexRebatesAplosFundId { get; set; }
         public string PexRebatesAplosTransactionAccountNumber { get; set; }
         public string PexRebatesAplosTaxTagId { get; set; }
-        
+
+        public bool SyncReimbursementsCreateContact { get; set; }
+        public int ReimbursementsAplosContactId { get; set; }
+        public int ReimbursementsAplosFundId { get; set; }
+        public string ReimbursementsAplosTransactionAccountNumber { get; set; }
+        public string ReimbursementsAplosTaxTagId { get; set; }
+
         public string ExpenseAccountMappings { get; set; }
         public string TagMappings { get; set; }
         public string TransferTagMappings { get; set; }
         public string FeeTagMappings { get; set; }
         public string RebateTagMappings { get; set; }
+        public string ReimbursementTagMappings { get; set; }
         
         public string PEXEmailAccount { get; set; }
         public string PEXNameAccount { get; set; }

--- a/src/AplosConnector.Common/Models/MappingSettingsModel.cs
+++ b/src/AplosConnector.Common/Models/MappingSettingsModel.cs
@@ -54,6 +54,10 @@ namespace AplosConnector.Common.Models
         /// Whether to sync PEX account fees to Aplos.
         /// </summary>
         public bool SyncPexFees { get; set; }
+        /// <summary>
+        /// Whether to sync PEX reimbursements to Aplos.
+        /// </summary>
+        public bool SyncReimbursements { get; set; }
 
         /// <summary>
         /// The AccountId for the register to use in Aplos. This is the account from which money will be taken from in the transaction created in Aplos.
@@ -85,11 +89,18 @@ namespace AplosConnector.Common.Models
         public decimal PexRebatesAplosTransactionAccountNumber { get; set; }
         public string PexRebatesAplosTaxTag { get; set; }
 
+        public bool SyncReimbursementsCreateContact { get; set; }
+        public int ReimbursementsAplosContactId { get; set; }
+        public int ReimbursementsAplosFundId { get; set; }
+        public decimal ReimbursementsAplosTransactionAccountNumber { get; set; }
+        public string ReimbursementsAplosTaxTag { get; set; }
+
         public ExpenseAccountMappingModel[] ExpenseAccountMappings { get; set; }
         public TagMappingModel[] TagMappings { get; set; }
         public AplosTagMappingModel[] TransferTagMappings { get; set; }
         public AplosTagMappingModel[] FeeTagMappings { get; set; }
         public AplosTagMappingModel[] RebateTagMappings { get; set; }
+        public AplosTagMappingModel[] ReimbursementTagMappings { get; set; }
         public FundingSource PEXFundingSource { get; set; }
 
         public double? SyncTransactionsIntervalDays { get; set; }

--- a/src/AplosConnector.Common/Models/Pex2AplosMappingModel.cs
+++ b/src/AplosConnector.Common/Models/Pex2AplosMappingModel.cs
@@ -26,6 +26,7 @@ namespace AplosConnector.Common.Models
             SyncPexFees = mapping.SyncPexFees;
             SyncInvoices = mapping.SyncInvoices;
             SyncRebates = mapping.SyncRebates;
+            SyncReimbursements = mapping.SyncReimbursements;
             LastSyncUtc = mapping.LastSync;
             EarliestTransactionDateToSync = mapping.EarliestTransactionDateToSync.ToUniversalTime();
             if (mapping.EndDateUtc != null)
@@ -64,6 +65,12 @@ namespace AplosConnector.Common.Models
             PexRebatesAplosTransactionAccountNumber = mapping.PexRebatesAplosTransactionAccountNumber;
             PexRebatesAplosTaxTagId = mapping.PexRebatesAplosTaxTag;
 
+            SyncReimbursementsCreateContact = mapping.SyncReimbursementsCreateContact;
+            ReimbursementsAplosContactId = mapping.ReimbursementsAplosContactId;
+            ReimbursementsAplosFundId = mapping.ReimbursementsAplosFundId;
+            ReimbursementsAplosTransactionAccountNumber = mapping.ReimbursementsAplosTransactionAccountNumber;
+            ReimbursementsAplosTaxTagId = mapping.ReimbursementsAplosTaxTag;
+
             PexFundsTagId = mapping.PexFundsTagId;
             SyncFundsToPex = mapping.SyncFundsToPex;
 
@@ -74,6 +81,7 @@ namespace AplosConnector.Common.Models
             TransferTagMappings = mapping.TransferTagMappings;
             FeeTagMappings = mapping.FeeTagMappings;
             RebateTagMappings = mapping.RebateTagMappings;
+            ReimbursementTagMappings = mapping.ReimbursementTagMappings;
             PEXFundingSource = mapping.PEXFundingSource;
             MapVendorCards = mapping.MapVendorCards;
             UseNormalizedMerchantNames = mapping.UseNormalizedMerchantNames;
@@ -108,6 +116,7 @@ namespace AplosConnector.Common.Models
                 SyncInvoices = SyncInvoices,
                 SyncPexFees = SyncPexFees,
                 SyncRebates = SyncRebates,
+                SyncReimbursements = SyncReimbursements,
                 LastSync = LastSyncUtc,
                 EarliestTransactionDateToSync = EarliestTransactionDateToSync,
                 EndDateUtc = EndDateUtc,
@@ -146,6 +155,12 @@ namespace AplosConnector.Common.Models
                 PexRebatesAplosTransactionAccountNumber = PexRebatesAplosTransactionAccountNumber,
                 PexRebatesAplosTaxTag = PexRebatesAplosTaxTagId,
 
+                SyncReimbursementsCreateContact = SyncReimbursementsCreateContact,
+                ReimbursementsAplosContactId = ReimbursementsAplosContactId,
+                ReimbursementsAplosFundId = ReimbursementsAplosFundId,
+                ReimbursementsAplosTransactionAccountNumber = ReimbursementsAplosTransactionAccountNumber,
+                ReimbursementsAplosTaxTag = ReimbursementsAplosTaxTagId,
+
                 SyncFundsToPex = SyncFundsToPex,
 
                 ExpenseAccountMappings = ExpenseAccountMappings,
@@ -153,6 +168,7 @@ namespace AplosConnector.Common.Models
                 TransferTagMappings = TransferTagMappings,
                 FeeTagMappings = FeeTagMappings,
                 RebateTagMappings = RebateTagMappings,
+                ReimbursementTagMappings = ReimbursementTagMappings,
                 PEXFundingSource = PEXFundingSource,
 
                 SyncTransactionsIntervalDays = SyncTransactionsIntervalDays,
@@ -186,6 +202,7 @@ namespace AplosConnector.Common.Models
         public bool SyncPexFees { get; set; }
         public bool SyncInvoices { get; set; }
         public bool SyncRebates { get; set; }
+        public bool SyncReimbursements { get; set; }
         public bool SyncApprovedOnly { get; set; }
         public DateTime EarliestTransactionDateToSync { get; set; }
         public DateTime? EndDateUtc { get; set; }
@@ -221,11 +238,18 @@ namespace AplosConnector.Common.Models
         public decimal PexRebatesAplosTransactionAccountNumber { get; set; }
         public string PexRebatesAplosTaxTagId { get; set; }
 
+        public bool SyncReimbursementsCreateContact { get; set; }
+        public int ReimbursementsAplosContactId { get; set; }
+        public int ReimbursementsAplosFundId { get; set; }
+        public decimal ReimbursementsAplosTransactionAccountNumber { get; set; }
+        public string ReimbursementsAplosTaxTagId { get; set; }
+
         public ExpenseAccountMappingModel[] ExpenseAccountMappings { get; set; }
         public TagMappingModel[] TagMappings { get; set; }
         public AplosTagMappingModel[] TransferTagMappings { get; set; }
         public AplosTagMappingModel[] FeeTagMappings { get; set; }
         public AplosTagMappingModel[] RebateTagMappings { get; set; }
+        public AplosTagMappingModel[] ReimbursementTagMappings { get; set; }
 
         public string PEXEmailAccount { get; set; }
         public string PEXNameAccount { get; set; }

--- a/src/AplosConnector.Common/Services/StorageMappingService.cs
+++ b/src/AplosConnector.Common/Services/StorageMappingService.cs
@@ -59,6 +59,7 @@ namespace AplosConnector.Common.Services
                     SyncInvoices = model.SyncInvoices,
                     SyncPexFees = model.SyncPexFees,
                     SyncRebates = model.SyncRebates,
+                    SyncReimbursements = model.SyncReimbursements,
                     SyncApprovedOnly = model.SyncApprovedOnly,
                     EarliestTransactionDateToSync = model.EarliestTransactionDateToSync,
                     EndDateUtc = model.EndDateUtc,
@@ -94,6 +95,12 @@ namespace AplosConnector.Common.Services
                     PexRebatesAplosTransactionAccountNumber = model.PexRebatesAplosTransactionAccountNumber.ToString(),
                     PexRebatesAplosTaxTagId = model.PexRebatesAplosTaxTagId,
 
+                    SyncReimbursementsCreateContact = model.SyncReimbursementsCreateContact,
+                    ReimbursementsAplosContactId = model.ReimbursementsAplosContactId,
+                    ReimbursementsAplosFundId = model.ReimbursementsAplosFundId,
+                    ReimbursementsAplosTransactionAccountNumber = model.ReimbursementsAplosTransactionAccountNumber.ToString(),
+                    ReimbursementsAplosTaxTagId = model.ReimbursementsAplosTaxTagId,
+
                     PexFundsTagId = model.PexFundsTagId,
                     SyncFundsToPex = model.SyncFundsToPex,
 
@@ -102,6 +109,7 @@ namespace AplosConnector.Common.Services
                     TransferTagMappings = JsonConvert.SerializeObject(model.TransferTagMappings),
                     FeeTagMappings = JsonConvert.SerializeObject(model.FeeTagMappings),
                     RebateTagMappings = JsonConvert.SerializeObject(model.RebateTagMappings),
+                    ReimbursementTagMappings = JsonConvert.SerializeObject(model.ReimbursementTagMappings),
 
                     PexTaxTagId = model.PexTaxTagId,
 
@@ -170,6 +178,7 @@ namespace AplosConnector.Common.Services
                 decimal.TryParse(model.TransfersAplosTransactionAccountNumber, out var transfersAplosTransactionAccountNumber);
                 decimal.TryParse(model.PexFeesAplosTransactionAccountNumber, out var pexFeesAplosTransactionAccountNumber);
                 decimal.TryParse(model.PexRebatesAplosTransactionAccountNumber, out var pexRebatesAplosTransactionAccountNumber);
+                decimal.TryParse(model.ReimbursementsAplosTransactionAccountNumber, out var reimbursementsAplosTransactionAccountNumber);
 
                 result = new Pex2AplosMappingModel
                 {
@@ -189,6 +198,7 @@ namespace AplosConnector.Common.Services
                     SyncInvoices = model.SyncInvoices,
                     SyncPexFees = model.SyncPexFees,
                     SyncRebates = model.SyncRebates,
+                    SyncReimbursements = model.SyncReimbursements,
                     SyncApprovedOnly = model.SyncApprovedOnly,
                     EarliestTransactionDateToSync = model.EarliestTransactionDateToSync,
                     EndDateUtc = model.EndDateUtc,
@@ -224,6 +234,12 @@ namespace AplosConnector.Common.Services
                     PexRebatesAplosTransactionAccountNumber = pexRebatesAplosTransactionAccountNumber,
                     PexRebatesAplosTaxTagId = model.PexRebatesAplosTaxTagId,
 
+                    SyncReimbursementsCreateContact = model.SyncReimbursementsCreateContact,
+                    ReimbursementsAplosContactId = model.ReimbursementsAplosContactId,
+                    ReimbursementsAplosFundId = model.ReimbursementsAplosFundId,
+                    ReimbursementsAplosTransactionAccountNumber = reimbursementsAplosTransactionAccountNumber,
+                    ReimbursementsAplosTaxTagId = model.ReimbursementsAplosTaxTagId,
+
                     PexFundsTagId = model.PexFundsTagId,
                     SyncFundsToPex = model.SyncFundsToPex,
 
@@ -246,6 +262,10 @@ namespace AplosConnector.Common.Services
                     RebateTagMappings = model.RebateTagMappings == null
                         ? null
                         : JsonConvert.DeserializeObject<AplosTagMappingModel[]>(model.RebateTagMappings),
+
+                    ReimbursementTagMappings = model.ReimbursementTagMappings == null
+                        ? null
+                        : JsonConvert.DeserializeObject<AplosTagMappingModel[]>(model.ReimbursementTagMappings),
 
                     PexTaxTagId = model.PexTaxTagId,
 

--- a/src/AplosConnector.Common/Services/StorageMappingService.cs
+++ b/src/AplosConnector.Common/Services/StorageMappingService.cs
@@ -248,9 +248,12 @@ namespace AplosConnector.Common.Services
 
                     ExpenseAccountMappings = model.ExpenseAccountMappings == null
                         ? null
-                        : JsonConvert.DeserializeObject<ExpenseAccountMappingModel[]>(model.ExpenseAccountMappings),                    TagMappings = model.TagMappings == null
+                        : JsonConvert.DeserializeObject<ExpenseAccountMappingModel[]>(model.ExpenseAccountMappings),
+
+                    TagMappings = model.TagMappings == null
                         ? null
                         : JsonConvert.DeserializeObject<TagMappingModel[]>(model.TagMappings),
+
                     TransferTagMappings = model.TransferTagMappings == null
                         ? null
                         : JsonConvert.DeserializeObject<AplosTagMappingModel[]>(model.TransferTagMappings),

--- a/tests/AplosConnector.Common.Tests/ReimbursementsRoundTripTests.cs
+++ b/tests/AplosConnector.Common.Tests/ReimbursementsRoundTripTests.cs
@@ -1,0 +1,145 @@
+using AplosConnector.Common.Models;
+using AplosConnector.Common.Services;
+using Microsoft.AspNetCore.DataProtection;
+using Xunit;
+
+namespace AplosConnector.Common.Tests
+{
+    public class ReimbursementsRoundTripTests
+    {
+        private static StorageMappingService NewService() =>
+            new StorageMappingService(new EphemeralDataProtectionProvider());
+
+        private static Pex2AplosMappingModel BuildModelWithReimbursements() => new Pex2AplosMappingModel
+        {
+            PEXBusinessAcctId = 12345,
+            SyncReimbursements = true,
+            SyncReimbursementsCreateContact = true,
+            ReimbursementsAplosContactId = 777,
+            ReimbursementsAplosFundId = 888,
+            ReimbursementsAplosTransactionAccountNumber = 6100.25m,
+            ReimbursementsAplosTaxTagId = "tax-tag-7",
+            ReimbursementTagMappings = new[]
+            {
+                new AplosTagMappingModel { AplosTagId = "tag-1", DefaultAplosTagValue = "value-1" },
+                new AplosTagMappingModel { AplosTagId = "tag-2", DefaultAplosTagValue = "value-2" }
+            }
+        };
+
+        [Fact]
+        public void EntityRoundTrip_PreservesReimbursementScalars()
+        {
+            var service = NewService();
+            var original = BuildModelWithReimbursements();
+
+            var entity = service.Map(original);
+            var roundTripped = service.Map(entity);
+
+            Assert.True(roundTripped.SyncReimbursements);
+            Assert.True(roundTripped.SyncReimbursementsCreateContact);
+            Assert.Equal(777, roundTripped.ReimbursementsAplosContactId);
+            Assert.Equal(888, roundTripped.ReimbursementsAplosFundId);
+            Assert.Equal(6100.25m, roundTripped.ReimbursementsAplosTransactionAccountNumber);
+            Assert.Equal("tax-tag-7", roundTripped.ReimbursementsAplosTaxTagId);
+        }
+
+        [Fact]
+        public void EntityRoundTrip_PreservesReimbursementTagMappings()
+        {
+            var service = NewService();
+            var original = BuildModelWithReimbursements();
+
+            var entity = service.Map(original);
+            var roundTripped = service.Map(entity);
+
+            Assert.NotNull(roundTripped.ReimbursementTagMappings);
+            Assert.Equal(2, roundTripped.ReimbursementTagMappings.Length);
+            Assert.Equal("tag-1", roundTripped.ReimbursementTagMappings[0].AplosTagId);
+            Assert.Equal("value-1", roundTripped.ReimbursementTagMappings[0].DefaultAplosTagValue);
+            Assert.Equal("tag-2", roundTripped.ReimbursementTagMappings[1].AplosTagId);
+        }
+
+        [Fact]
+        public void EntityRoundTrip_DefaultModelHasReimbursementsDisabled()
+        {
+            var service = NewService();
+            var original = new Pex2AplosMappingModel { PEXBusinessAcctId = 1 };
+
+            var entity = service.Map(original);
+            var roundTripped = service.Map(entity);
+
+            Assert.False(roundTripped.SyncReimbursements);
+            Assert.False(roundTripped.SyncReimbursementsCreateContact);
+            Assert.Equal(0, roundTripped.ReimbursementsAplosContactId);
+            Assert.Equal(0, roundTripped.ReimbursementsAplosFundId);
+            Assert.Equal(0m, roundTripped.ReimbursementsAplosTransactionAccountNumber);
+            Assert.Null(roundTripped.ReimbursementsAplosTaxTagId);
+        }
+
+        [Fact]
+        public void SettingsRoundTrip_PreservesReimbursementFields()
+        {
+            var original = BuildModelWithReimbursements();
+
+            var settings = original.ToStorageModel();
+            var rebuilt = new Pex2AplosMappingModel { PEXBusinessAcctId = original.PEXBusinessAcctId };
+            rebuilt.UpdateFromSettings(settings);
+
+            Assert.True(rebuilt.SyncReimbursements);
+            Assert.True(rebuilt.SyncReimbursementsCreateContact);
+            Assert.Equal(777, rebuilt.ReimbursementsAplosContactId);
+            Assert.Equal(888, rebuilt.ReimbursementsAplosFundId);
+            Assert.Equal(6100.25m, rebuilt.ReimbursementsAplosTransactionAccountNumber);
+            Assert.Equal("tax-tag-7", rebuilt.ReimbursementsAplosTaxTagId);
+            Assert.NotNull(rebuilt.ReimbursementTagMappings);
+            Assert.Equal(2, rebuilt.ReimbursementTagMappings.Length);
+        }
+
+        [Fact]
+        public void SettingsModel_TaxTagPropertyDropsIdSuffix()
+        {
+            // MappingSettingsModel uses *TaxTag (no Id suffix), domain model uses *TaxTagId.
+            // Guards against accidental rename drift between the two models.
+            var original = BuildModelWithReimbursements();
+
+            var settings = original.ToStorageModel();
+
+            Assert.Equal("tax-tag-7", settings.ReimbursementsAplosTaxTag);
+        }
+
+        [Fact]
+        public void EntityRoundTrip_NullTagMappings_RemainsNull()
+        {
+            var service = NewService();
+            var original = new Pex2AplosMappingModel
+            {
+                PEXBusinessAcctId = 1,
+                SyncReimbursements = true,
+                ReimbursementTagMappings = null
+            };
+
+            var entity = service.Map(original);
+            var roundTripped = service.Map(entity);
+
+            Assert.Null(roundTripped.ReimbursementTagMappings);
+        }
+
+        [Fact]
+        public void EntityRoundTrip_EmptyTagMappings_RoundTripsToEmptyArray()
+        {
+            var service = NewService();
+            var original = new Pex2AplosMappingModel
+            {
+                PEXBusinessAcctId = 1,
+                SyncReimbursements = true,
+                ReimbursementTagMappings = new AplosTagMappingModel[0]
+            };
+
+            var entity = service.Map(original);
+            var roundTripped = service.Map(entity);
+
+            Assert.NotNull(roundTripped.ReimbursementTagMappings);
+            Assert.Empty(roundTripped.ReimbursementTagMappings);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds reimbursement-specific configuration fields to `Pex2AplosMappingModel` (runtime), `Pex2AplosMappingEntity` (Azure Table Storage), and `MappingSettingsModel` (API transfer), so the frontend reimbursement settings can be persisted and read back.
- Updates `StorageMappingService` to serialize/deserialize the new fields, including JSON handling for the `ReimbursementTagMappings` array and decimal parsing for the account number — mirroring the existing `PexRebates*` family.
- Existing mappings without these fields default to `SyncReimbursements = false` and `ReimbursementTagMappings = null`, so deployment is additive and backward-compatible (no migration, no behavior change for current accounts).
- Adds round-trip tests covering scalar fields, populated/null/empty tag-mapping arrays, the default-disabled state, and a guard against `*TaxTag` vs `*TaxTagId` naming drift between models.

Work item: [AB#140664](https://pexcard.visualstudio.com/aeed64c4-c884-4a53-8682-73e24201472f/_workitems/edit/140664)

## Note for reviewers

The "create contact per employee" flag is named `SyncReimbursementsCreateContact` in code, whereas work item 140664's acceptance criteria text uses `ReimbursementsCreateContactPerEmployee`. The code name is intentional — it is consistent with the `SyncReimbursements*` field family and is already referenced by the sync logic (follow-up PR) and the frontend. Flagging only because it diverges from the AC wording.

---

<sub>Co-authored with Claude Code (model: claude-opus-4-8)</sub>