### PR TITLE
pex-connector-aplos: Implement reimbursement sync (SyncReimbursements)

### DIFF
--- a/src/AplosConnector.Common/Services/AplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/AplosIntegrationService.cs
@@ -81,6 +81,7 @@ namespace AplosConnector.Common.Services
                     AplosAuthenticationMode = AplosAuthenticationMode.PartnerAuthentication,
                     SyncApprovedOnly = true,
                     SyncTransactionsCreateContact = true,
+                    SyncReimbursementsCreateContact = true,
                     MapVendorCards = true,
                     UseNormalizedMerchantNames = true
                 };
@@ -578,6 +579,15 @@ namespace AplosConnector.Common.Services
                     catch (Exception ex)
                     {
                         _logger.LogWarning(ex, $"Exception during {nameof(SyncAplosTaxTagsToPex)} for business: {mapping.PEXBusinessAcctId}.");
+                    }
+
+                    try
+                    {
+                        await SyncReimbursements(_logger, mapping, utcNow, cancellationToken);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, $"Exception during {nameof(SyncReimbursements)} for business: {mapping.PEXBusinessAcctId}.");
                     }
                 }
 
@@ -2518,6 +2528,436 @@ namespace AplosConnector.Common.Services
         }
 
         #endregion
+
+        private async Task SyncReimbursements(
+            ILogger logger,
+            Pex2AplosMappingModel mapping,
+            DateTime utcNow,
+            CancellationToken cancellationToken)
+        {
+            if (!mapping.SyncReimbursements) return;
+
+            if (!(mapping.SyncReimbursementsCreateContact || mapping.ReimbursementsAplosContactId > 0)
+                || mapping.ReimbursementsAplosFundId <= 0
+                || mapping.ReimbursementsAplosTransactionAccountNumber <= 0)
+            {
+                logger.LogInformation($"Skipping sync reimbursements for business {mapping.PEXBusinessAcctId}. Reimbursements are not configured.");
+                return;
+            }
+
+            var startDateUtc = GetStartDateUtc(mapping, utcNow, _syncSettings);
+            var endDateUtc = GetEndDateUtc(mapping.EndDateUtc, utcNow);
+
+            if (startDateUtc.Date >= endDateUtc.Date)
+            {
+                return;
+            }
+
+            // Fetch Aplos transactions for dedup
+            var startDate = startDateUtc.ToStartOfDay(TimeZones.EST);
+            var aplosTransactions = await GetTransactions(mapping, startDate, cancellationToken);
+
+            // Fetch Aplos reference data for tag resolution
+            var aplosFunds = (await GetAplosFunds(mapping, cancellationToken)).ToList();
+            var aplosAccountCategory = GetAplosAccountCategory();
+            var aplosExpenseAccounts = (await GetAplosAccounts(mapping, aplosAccountCategory, cancellationToken)).ToList();
+            var aplosTags = (await GetFlattenedAplosTagValues(mapping, cancellationToken)).ToList();
+
+            // Fetch PEX dropdown tag definitions for tag answer resolution
+            var useTags = await _pexApiClient.IsTagsAvailable(mapping.PEXExternalAPIToken, CustomFieldType.Dropdown, cancellationToken);
+            List<TagDropdownDetailsModel> dropdownTags = default;
+            if (useTags)
+            {
+                var dropdownTagTasks = new List<Task<TagDropdownDetailsModel>>();
+
+                if (!string.IsNullOrEmpty(mapping.PexFundsTagId))
+                {
+                    dropdownTagTasks.Add(_pexApiClient.GetDropdownTag(mapping.PEXExternalAPIToken, mapping.PexFundsTagId, true, cancellationToken));
+                }
+                if (mapping.ExpenseAccountMappings != null)
+                {
+                    foreach (var expenseAccountMapping in mapping.ExpenseAccountMappings)
+                    {
+                        dropdownTagTasks.Add(_pexApiClient.GetDropdownTag(mapping.PEXExternalAPIToken, expenseAccountMapping.ExpenseAccountsPexTagId, true, cancellationToken));
+                    }
+                }
+                if (mapping.TagMappings != null)
+                {
+                    foreach (var tagMapping in mapping.TagMappings)
+                    {
+                        dropdownTagTasks.Add(_pexApiClient.GetDropdownTag(mapping.PEXExternalAPIToken, tagMapping.PexTagId, true, cancellationToken));
+                    }
+                }
+                await Task.WhenAll(dropdownTagTasks);
+                dropdownTags = dropdownTagTasks.Where(t => !t.IsFaulted).Select(t => t.Result).ToList();
+                foreach (var failedTask in dropdownTagTasks.Where(t => t.IsFaulted))
+                {
+                    logger.LogError(failedTask.Exception?.InnerException, $"Exception getting dropdown tag for business {mapping.PEXBusinessAcctId}. {failedTask.Exception?.InnerException}");
+                }
+
+                logger.LogInformation($"Retrieved {dropdownTags.Count} PEX dropdown tags for reimbursement sync.");
+            }
+
+            // Fetch reimbursement payments from PEX. Mirror the sibling connectors (QBO/Intacct/Blackbaud):
+            // pull the full in-flight-and-settled trigger set filtered by outbound ACH creation date, then
+            // only post the fully-settled ones below. In-flight payments are re-fetched on the next run.
+            var paymentRequest = new PaymentListRequestModel
+            {
+                PaymentStatuses = new List<PaymentStatus> { PaymentStatus.Pending, PaymentStatus.Closed },
+                PaymentStatusTriggers = new List<PaymentStatusTrigger>
+                {
+                    PaymentStatusTrigger.Settling,
+                    PaymentStatusTrigger.AwaitingOutboundCompletion,
+                    PaymentStatusTrigger.Settled,
+                    PaymentStatusTrigger.Returned,
+                    PaymentStatusTrigger.Cancelled,
+                },
+                OutboundAchCreationStartDate = startDateUtc,
+                OutboundAchCreationEndDate = endDateUtc,
+            };
+
+            // Page through all matching payments first.
+            var payments = new List<PaymentModel>();
+            var page = 1;
+            const int pageSize = 50;
+            long totalItems = 0;
+
+            do
+            {
+                var paymentsPage = await _pexApiClient.GetPayments(mapping.PEXExternalAPIToken, paymentRequest, page, pageSize, cancellationToken);
+
+                if (paymentsPage?.Items == null || paymentsPage.Items.Count == 0)
+                {
+                    break;
+                }
+
+                payments.AddRange(paymentsPage.Items);
+                totalItems = paymentsPage.PageInfo?.TotalItems ?? payments.Count;
+                page++;
+            } while (payments.Count < totalItems);
+
+            // Map each payment's settlement trigger by PaymentId so we can post only fully-settled reimbursements.
+            var paymentTriggersByPaymentId = payments
+                .GroupBy(p => p.PaymentId)
+                .ToDictionary(g => g.Key, g => g.First().PaymentStatusTrigger);
+
+            // Resolve the unique transfers for those payments, then their reimbursement payment requests.
+            var allPaymentRequests = new List<PaymentRequestModel>();
+            var transferIds = payments.Select(p => p.PaymentTransferId).Distinct().ToList();
+
+            foreach (var transferId in transferIds)
+            {
+                PaymentTransferModel transfer;
+                try
+                {
+                    transfer = await _pexApiClient.GetPaymentTransfer(mapping.PEXExternalAPIToken, transferId, cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex, $"Error fetching payment transfer {transferId} for business {mapping.PEXBusinessAcctId}. Skipping.");
+                    continue;
+                }
+
+                if (transfer?.PaymentRequests == null) continue;
+
+                foreach (var prLink in transfer.PaymentRequests)
+                {
+                    PaymentRequestModel pr;
+                    try
+                    {
+                        pr = await _pexApiClient.GetPaymentRequest(mapping.PEXExternalAPIToken, prLink.PaymentRequestId, cancellationToken);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogWarning(ex, $"Error fetching payment request {prLink.PaymentRequestId} for business {mapping.PEXBusinessAcctId}. Skipping.");
+                        continue;
+                    }
+
+                    if (pr != null && pr.PaymentRequestType == PaymentRequestType.Reimbursement)
+                    {
+                        allPaymentRequests.Add(pr);
+                    }
+                }
+            }
+
+            allPaymentRequests = allPaymentRequests
+                .DistinctBy(pr => pr.PaymentRequestId)
+                .ToList();
+
+            // Only sync reimbursements whose payment is fully settled (paid) and not already in Aplos.
+            // Returned/Cancelled/in-flight requests are skipped; in-flight ones settle on a later run.
+            var reimbursementsToSync = allPaymentRequests
+                .Where(pr => pr.PaymentId.HasValue
+                    && paymentTriggersByPaymentId.TryGetValue(pr.PaymentId.Value, out var trigger)
+                    && trigger == PaymentStatusTrigger.Settled)
+                .Where(pr => !WasPexTransactionSyncedToAplos(aplosTransactions, pr.PaymentRequestId.ToString()))
+                .ToList();
+
+            logger.LogInformation($"Found {allPaymentRequests.Count} reimbursement payment requests, {reimbursementsToSync.Count} to sync for business {mapping.PEXBusinessAcctId}.");
+
+            var syncCount = 0;
+            var failureCount = 0;
+
+            foreach (var pr in reimbursementsToSync)
+            {
+                using (logger.BeginScope(GetLoggingScopeForReimbursement(pr)))
+                {
+                    logger.LogDebug($"Starting sync for PEX reimbursement {pr.PaymentRequestId}");
+
+                    try
+                    {
+                        var pexTagValues = new PexTagValuesModel
+                        {
+                            AplosRegisterAccountNumber = mapping.AplosRegisterAccountNumber,
+                            AplosContactId = mapping.ReimbursementsAplosContactId,
+                            AplosFundId = mapping.ReimbursementsAplosFundId,
+                            AplosTaxTagId = mapping.ReimbursementsAplosTaxTagId,
+                            AplosTransactionAccountNumber = mapping.ReimbursementsAplosTransactionAccountNumber,
+                        };
+
+                        // Apply reimbursement default Aplos tags. Reimbursement category tags
+                        // (Fundraisers/Projects/Departments/Custom) are configured in
+                        // ReimbursementTagMappings, not TagMappings. Apply them unconditionally,
+                        // consistent with how transfers/fees/rebates apply their own *TagMappings.
+                        ApplyTagMappingsToTagValues(pexTagValues, mapping.ReimbursementTagMappings, logger);
+
+                        // Resolve fund, expense account, and tax tag dynamically from PEX tag answers if available
+                        var tagAnswers = pr.Metadata?.TagAnswers;
+                        if (useTags && tagAnswers != null)
+                        {
+                            // Resolve fund from tag answers
+                            var fundTagAnswer = GetReimbursementTagAnswer(tagAnswers, mapping.PexFundsTagId);
+                            if (fundTagAnswer != null)
+                            {
+                                var fundTagValueItem = new TagValueItem { TagId = fundTagAnswer.FieldId, Value = fundTagAnswer.Value };
+                                var fundTagDefinition = dropdownTags?.FirstOrDefault(t => t.Id.Equals(fundTagAnswer.FieldId, StringComparison.InvariantCultureIgnoreCase));
+                                var fundTagOptionValue = fundTagAnswer.Value?.ToString();
+                                var fundTagOptionName = fundTagValueItem.GetTagOptionName(fundTagDefinition?.Options);
+                                var fundEntity = aplosFunds.FindMatchingEntity(fundTagOptionValue, fundTagOptionName, ':', logger);
+                                if (fundEntity != null && int.TryParse(fundEntity.Id, out var aplosFundId))
+                                {
+                                    logger.LogDebug($"Matched PEX fund tag option ['{fundTagOptionName}' : '{fundTagOptionValue}'] with Aplos fund '{fundEntity.Name}' ({fundEntity.Id}) on reimbursement {pr.PaymentRequestId}.");
+                                    pexTagValues.AplosFundId = aplosFundId;
+                                }
+                                else
+                                {
+                                    logger.LogInformation($"Could not match fund tag on reimbursement {pr.PaymentRequestId}. Using default fund {mapping.ReimbursementsAplosFundId}.");
+                                }
+                            }
+
+                            // Resolve expense account from tag answers
+                            if (mapping.ExpenseAccountMappings != null)
+                            {
+                                TagValueItem expenseAccountTagItem = null;
+                                decimal defaultAccountNumber = 0;
+
+                                foreach (var expenseAccountMapping in mapping.ExpenseAccountMappings)
+                                {
+                                    var accountTagAnswer = GetReimbursementTagAnswer(tagAnswers, expenseAccountMapping.ExpenseAccountsPexTagId);
+                                    if (accountTagAnswer != null)
+                                    {
+                                        expenseAccountTagItem = new TagValueItem { TagId = accountTagAnswer.FieldId, Value = accountTagAnswer.Value };
+                                        break;
+                                    }
+                                    defaultAccountNumber = expenseAccountMapping.DefaultAplosTransactionAccountNumber;
+                                }
+
+                                if (expenseAccountTagItem != null)
+                                {
+                                    var accountTagDefinition = dropdownTags?.FirstOrDefault(t => t.Id.Equals(expenseAccountTagItem.TagId, StringComparison.InvariantCultureIgnoreCase));
+                                    var accountTagOptionName = expenseAccountTagItem.GetTagOptionName(accountTagDefinition?.Options);
+                                    var accountTagOptionValue = expenseAccountTagItem.Value?.ToString();
+                                    var accountEntity = aplosExpenseAccounts.FindMatchingEntity(accountTagOptionValue, accountTagOptionName, ':', logger);
+                                    if (accountEntity != null && decimal.TryParse(accountEntity.Id, out var aplosAccountNumber))
+                                    {
+                                        logger.LogDebug($"Matched PEX account tag option ['{accountTagOptionName}' : '{accountTagOptionValue}'] with Aplos account '{accountEntity.Name}' ({accountEntity.Id}) on reimbursement {pr.PaymentRequestId}.");
+                                        pexTagValues.AplosTransactionAccountNumber = aplosAccountNumber;
+                                    }
+                                    else
+                                    {
+                                        logger.LogInformation($"Could not match expense account tag on reimbursement {pr.PaymentRequestId}. Using default account {mapping.ReimbursementsAplosTransactionAccountNumber}.");
+                                    }
+                                }
+                                else if (defaultAccountNumber > 0)
+                                {
+                                    pexTagValues.AplosTransactionAccountNumber = defaultAccountNumber;
+                                }
+                            }
+
+                            // Resolve 990 tax tag from tag answers
+                            var taxTagAnswer = GetReimbursementTagAnswer(tagAnswers, mapping.PexTaxTagId);
+                            if (taxTagAnswer?.Value != null)
+                            {
+                                logger.LogInformation($"Using reimbursement tag {mapping.PexTaxTagId} for reimbursement {pr.PaymentRequestId} as Aplos tax tag value '{taxTagAnswer.Value}'.");
+                                pexTagValues.AplosTaxTagId = taxTagAnswer.Value.ToString();
+                            }
+                        }
+
+                        // Build double-entry lines
+                        var amount = pr.Amount;
+
+                        var registerLine = new AplosApiTransactionLineDetail
+                        {
+                            Account = new AplosApiAccountDetail { AccountNumber = pexTagValues.AplosRegisterAccountNumber },
+                            Amount = -amount,
+                            Fund = new AplosApiFundDetail { Id = pexTagValues.AplosFundId },
+                        };
+
+                        var expenseLine = new AplosApiTransactionLineDetail
+                        {
+                            Account = new AplosApiAccountDetail { AccountNumber = pexTagValues.AplosTransactionAccountNumber },
+                            Amount = amount,
+                            Fund = new AplosApiFundDetail { Id = pexTagValues.AplosFundId },
+                        };
+
+                        if (pexTagValues.AplosTagIds != null)
+                        {
+                            expenseLine.Tags = new List<AplosApiTagDetail>();
+                            foreach (var aplosTagId in pexTagValues.AplosTagIds)
+                            {
+                                expenseLine.Tags.Add(new AplosApiTagDetail { Id = aplosTagId });
+                            }
+                        }
+
+                        if (!string.IsNullOrWhiteSpace(pexTagValues.AplosTaxTagId))
+                        {
+                            expenseLine.TaxTag = new AplosApiTaxTagDetail { Id = pexTagValues.AplosTaxTagId };
+                        }
+
+                        // Build note with payee info and payment request ID for dedup
+                        const int noteMaxLength = 1000;
+                        var paymentRequestIdString = pr.PaymentRequestId.ToString();
+                        var idSuffix = $" | {paymentRequestIdString}";
+                        var maxContentLength = noteMaxLength - idSuffix.Length;
+
+                        var noteBuilder = new StringBuilder();
+                        if (!string.IsNullOrEmpty(pr.MerchantName))
+                        {
+                            noteBuilder.Append(pr.MerchantName);
+                        }
+
+                        var payeeName = $"{pr.UserFirstName} {pr.UserLastName}".Trim();
+                        if (!string.IsNullOrEmpty(payeeName))
+                        {
+                            if (noteBuilder.Length > 0) noteBuilder.Append(" | ");
+                            noteBuilder.Append(payeeName);
+                        }
+
+                        if (!string.IsNullOrEmpty(pr.Note))
+                        {
+                            if (noteBuilder.Length > 0) noteBuilder.Append(" | ");
+                            noteBuilder.Append(pr.Note);
+                        }
+
+                        var noteContent = noteBuilder.Length > maxContentLength
+                            ? noteBuilder.ToString(0, maxContentLength)
+                            : noteBuilder.ToString();
+
+                        var aplosNote = string.IsNullOrEmpty(noteContent)
+                            ? paymentRequestIdString
+                            : noteContent + idSuffix;
+
+                        // Determine post date
+                        DateTime postDate;
+                        if (mapping.PostDateType == PostDateType.Settlement && pr.PayoutDate.HasValue)
+                        {
+                            postDate = pr.PayoutDate.Value.DateTime;
+                        }
+                        else
+                        {
+                            postDate = pr.PurchaseDate.DateTime;
+                        }
+
+                        // Determine contact — auto-create from employee name or use default
+                        AplosApiContactDetail contact;
+                        if (mapping.SyncReimbursementsCreateContact)
+                        {
+                            if (!string.IsNullOrEmpty(payeeName))
+                            {
+                                contact = new AplosApiContactDetail { CompanyName = payeeName, Type = "individual" };
+                            }
+                            else
+                            {
+                                contact = new AplosApiContactDetail { Id = pexTagValues.AplosContactId };
+                            }
+                        }
+                        else
+                        {
+                            contact = new AplosApiContactDetail { Id = pexTagValues.AplosContactId };
+                        }
+
+                        var aplosTransaction = new AplosApiTransactionDetail
+                        {
+                            Contact = contact,
+                            Amount = amount,
+                            Date = postDate,
+                            Note = aplosNote,
+                            Lines = new[] { registerLine, expenseLine },
+                        };
+
+                        var aplosApiClient = MakeAplosApiClient(mapping);
+                        await aplosApiClient.CreateTransaction(aplosTransaction, cancellationToken);
+
+                        syncCount++;
+                        logger.LogInformation($"Synced reimbursement {pr.PaymentRequestId} with Aplos");
+                    }
+                    catch (Exception ex)
+                    {
+                        failureCount++;
+                        logger.LogError(ex, $"Error processing reimbursement {pr.PaymentRequestId}.");
+                    }
+                }
+            }
+
+            var syncNote = failureCount == 0 ? string.Empty : $"Failed to sync {failureCount} reimbursements from PEX.";
+            SyncStatus syncStatus;
+            if (failureCount == 0)
+            {
+                syncStatus = SyncStatus.Success;
+            }
+            else if (syncCount != 0)
+            {
+                syncStatus = SyncStatus.Partial;
+            }
+            else
+            {
+                syncStatus = SyncStatus.Failed;
+            }
+
+            var result = new SyncResultModel
+            {
+                PEXBusinessAcctId = mapping.PEXBusinessAcctId,
+                SyncType = "Reimbursements",
+                SyncStatus = syncStatus.ToString(),
+                SyncedRecords = syncCount,
+                SyncNotes = syncNote
+            };
+            await _historyStorage.CreateAsync(result, cancellationToken);
+        }
+
+        private static TagAnswerModel GetReimbursementTagAnswer(IEnumerable<TagAnswerModel> tagAnswers, string fieldId)
+        {
+            if (string.IsNullOrEmpty(fieldId) || tagAnswers == null) return null;
+            return tagAnswers.FirstOrDefault(ta => ta.FieldId != null && ta.FieldId.Equals(fieldId, StringComparison.InvariantCultureIgnoreCase));
+        }
+
+        private static IDictionary<string, object> GetLoggingScopeForReimbursement(PaymentRequestModel paymentRequest)
+        {
+            if (paymentRequest is null)
+            {
+                throw new ArgumentNullException(nameof(paymentRequest));
+            }
+
+            return new Dictionary<string, object>
+            {
+                ["PaymentRequestId"] = paymentRequest.PaymentRequestId,
+                ["PaymentRequestType"] = paymentRequest.PaymentRequestType,
+                ["Amount"] = paymentRequest.Amount,
+                ["MerchantName"] = paymentRequest.MerchantName,
+                ["PurchaseDate"] = paymentRequest.PurchaseDate,
+                ["PayoutDate"] = paymentRequest.PayoutDate,
+            };
+        }
 
         private void ApplyTagMappingsToTagValues(PexTagValuesModel pexTagValues, AplosTagMappingModel[] tagMappings, ILogger logger)
         {

--- a/src/AplosConnector.Common/Services/AplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/AplosIntegrationService.cs
@@ -2587,7 +2587,7 @@ namespace AplosConnector.Common.Services
                         dropdownTagTasks.Add(_pexApiClient.GetDropdownTag(mapping.PEXExternalAPIToken, tagMapping.PexTagId, true, cancellationToken));
                     }
                 }
-                await Task.WhenAll(dropdownTagTasks);
+                try { await Task.WhenAll(dropdownTagTasks); } catch { /* handled below */ }
                 dropdownTags = dropdownTagTasks.Where(t => !t.IsFaulted).Select(t => t.Result).ToList();
                 foreach (var failedTask in dropdownTagTasks.Where(t => t.IsFaulted))
                 {

--- a/src/AplosConnector.Common/Services/AplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/AplosIntegrationService.cs
@@ -2869,19 +2869,21 @@ namespace AplosConnector.Common.Services
 
                         // Determine contact — auto-create from employee name or use default
                         AplosApiContactDetail contact;
-                        if (mapping.SyncReimbursementsCreateContact)
+                        if (mapping.SyncReimbursementsCreateContact && !string.IsNullOrEmpty(payeeName))
                         {
-                            if (!string.IsNullOrEmpty(payeeName))
-                            {
-                                contact = new AplosApiContactDetail { CompanyName = payeeName, Type = "individual" };
-                            }
-                            else
-                            {
-                                contact = new AplosApiContactDetail { Id = pexTagValues.AplosContactId };
-                            }
+                            contact = new AplosApiContactDetail { CompanyName = payeeName, Type = "individual" };
                         }
                         else
                         {
+                            // Fall back to the configured default contact. In create-contact mode a blank
+                            // payee name has no valid contact to fall back to (the guard allows contact id 0),
+                            // so skip this reimbursement rather than post an invalid contact id to Aplos.
+                            if (pexTagValues.AplosContactId <= 0)
+                            {
+                                logger.LogWarning($"Skipping reimbursement {pr.PaymentRequestId} for business {mapping.PEXBusinessAcctId}. Create-contact is enabled but the payee name is blank and no default contact is configured.");
+                                continue;
+                            }
+
                             contact = new AplosApiContactDetail { Id = pexTagValues.AplosContactId };
                         }
 

--- a/src/AplosConnector.Common/Services/AplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/AplosIntegrationService.cs
@@ -2561,7 +2561,6 @@ namespace AplosConnector.Common.Services
             var aplosFunds = (await GetAplosFunds(mapping, cancellationToken)).ToList();
             var aplosAccountCategory = GetAplosAccountCategory();
             var aplosExpenseAccounts = (await GetAplosAccounts(mapping, aplosAccountCategory, cancellationToken)).ToList();
-            var aplosTags = (await GetFlattenedAplosTagValues(mapping, cancellationToken)).ToList();
 
             // Fetch PEX dropdown tag definitions for tag answer resolution
             var useTags = await _pexApiClient.IsTagsAvailable(mapping.PEXExternalAPIToken, CustomFieldType.Dropdown, cancellationToken);

--- a/src/AplosConnector.Common/Services/AplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/AplosIntegrationService.cs
@@ -2882,6 +2882,9 @@ namespace AplosConnector.Common.Services
                             else
                             {
                                 // Create-contact mode with a blank employee name and no fallback contact configured.
+                                // Count as a failure (not a silent skip) so the misconfiguration surfaces in the sync
+                                // status, matching how SyncTransactions/SyncInvoices treat ineligible-but-expected records.
+                                failureCount++;
                                 logger.LogWarning($"Skipping reimbursement {pr.PaymentRequestId} for business {mapping.PEXBusinessAcctId}. Auto-create contact is enabled but the payee name is empty and no default contact is configured.");
                                 continue;
                             }

--- a/src/AplosConnector.Common/Services/AplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/AplosIntegrationService.cs
@@ -1016,7 +1016,7 @@ namespace AplosConnector.Common.Services
                         dropdownTagTasks.Add(_pexApiClient.GetDropdownTag(mapping.PEXExternalAPIToken, tagMapping.PexTagId, true, cancellationToken));
                     }
                 }
-                await Task.WhenAll(dropdownTagTasks);
+                try { await Task.WhenAll(dropdownTagTasks); } catch { /* faulted tasks handled below */ }
                 dropdownTags = dropdownTagTasks.Where(t => !t.IsFaulted).Select(t => t.Result).ToList();
                 foreach (var failedTask in dropdownTagTasks.Where(t => t.IsFaulted))
                 {
@@ -2758,7 +2758,12 @@ namespace AplosConnector.Common.Services
                                         expenseAccountTagItem = new TagValueItem { TagId = accountTagAnswer.FieldId, Value = accountTagAnswer.Value };
                                         break;
                                     }
-                                    defaultAccountNumber = expenseAccountMapping.DefaultAplosTransactionAccountNumber;
+                                    // Keep the first configured positive default so the fallback is deterministic
+                                    // and not dependent on ExpenseAccountMappings ordering.
+                                    if (defaultAccountNumber <= 0 && expenseAccountMapping.DefaultAplosTransactionAccountNumber > 0)
+                                    {
+                                        defaultAccountNumber = expenseAccountMapping.DefaultAplosTransactionAccountNumber;
+                                    }
                                 }
 
                                 if (expenseAccountTagItem != null)

--- a/src/AplosConnector.Common/Services/AplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/AplosIntegrationService.cs
@@ -2869,21 +2869,25 @@ namespace AplosConnector.Common.Services
 
                         // Determine contact — auto-create from employee name or use default
                         AplosApiContactDetail contact;
-                        if (mapping.SyncReimbursementsCreateContact && !string.IsNullOrEmpty(payeeName))
+                        if (mapping.SyncReimbursementsCreateContact)
                         {
-                            contact = new AplosApiContactDetail { CompanyName = payeeName, Type = "individual" };
+                            if (!string.IsNullOrEmpty(payeeName))
+                            {
+                                contact = new AplosApiContactDetail { CompanyName = payeeName, Type = "individual" };
+                            }
+                            else if (pexTagValues.AplosContactId > 0)
+                            {
+                                contact = new AplosApiContactDetail { Id = pexTagValues.AplosContactId };
+                            }
+                            else
+                            {
+                                // Create-contact mode with a blank employee name and no fallback contact configured.
+                                logger.LogWarning($"Skipping reimbursement {pr.PaymentRequestId} for business {mapping.PEXBusinessAcctId}. Auto-create contact is enabled but the payee name is empty and no default contact is configured.");
+                                continue;
+                            }
                         }
                         else
                         {
-                            // Fall back to the configured default contact. In create-contact mode a blank
-                            // payee name has no valid contact to fall back to (the guard allows contact id 0),
-                            // so skip this reimbursement rather than post an invalid contact id to Aplos.
-                            if (pexTagValues.AplosContactId <= 0)
-                            {
-                                logger.LogWarning($"Skipping reimbursement {pr.PaymentRequestId} for business {mapping.PEXBusinessAcctId}. Create-contact is enabled but the payee name is blank and no default contact is configured.");
-                                continue;
-                            }
-
                             contact = new AplosApiContactDetail { Id = pexTagValues.AplosContactId };
                         }
 

--- a/src/AplosConnector.Web/Controllers/PEXController.cs
+++ b/src/AplosConnector.Web/Controllers/PEXController.cs
@@ -173,7 +173,7 @@ namespace AplosConnector.Web.Controllers
                 Name = mapping.PEXNameAccount,
                 IsSyncing = mapping.IsSyncing,
                 LastSync = mapping.LastSyncUtc,
-                SyncingSetup = mapping.SyncInvoices || mapping.SyncTransactions || mapping.SyncTransfers || mapping.SyncPexFees || mapping.SyncFundsToPex || mapping.SyncTaxTagToPex || mapping.SyncReimbursements
+                SyncingSetup = mapping.SyncInvoices || mapping.SyncTransactions || mapping.SyncTransfers || mapping.SyncPexFees || mapping.SyncRebates || mapping.SyncFundsToPex || mapping.SyncTaxTagToPex || mapping.SyncReimbursements
             };
 
             try

--- a/src/AplosConnector.Web/Controllers/PEXController.cs
+++ b/src/AplosConnector.Web/Controllers/PEXController.cs
@@ -173,7 +173,7 @@ namespace AplosConnector.Web.Controllers
                 Name = mapping.PEXNameAccount,
                 IsSyncing = mapping.IsSyncing,
                 LastSync = mapping.LastSyncUtc,
-                SyncingSetup = mapping.SyncInvoices || mapping.SyncTransactions || mapping.SyncTransfers || mapping.SyncPexFees || mapping.SyncFundsToPex || mapping.SyncTaxTagToPex
+                SyncingSetup = mapping.SyncInvoices || mapping.SyncTransactions || mapping.SyncTransfers || mapping.SyncPexFees || mapping.SyncFundsToPex || mapping.SyncTaxTagToPex || mapping.SyncReimbursements
             };
 
             try

--- a/tests/AplosConnector.Common.Tests/AplosIntegrationServiceTests.cs
+++ b/tests/AplosConnector.Common.Tests/AplosIntegrationServiceTests.cs
@@ -510,6 +510,78 @@ namespace AplosConnector.Common.Tests
         }
 
         [Fact]
+        public void WasPexTransactionSyncedToAplos_ReturnsTrue_WhenPaymentRequestIdIsInNoteSuffix()
+        {
+            //Arrange — reimbursement note format: "MerchantName | PayeeName | 12345"
+            string paymentRequestId = "12345";
+
+            var aplosTransactions = new List<AplosApiTransactionDetail>
+            {
+                new AplosApiTransactionDetail
+                {
+                    Note = $"Merchant | John Doe | {paymentRequestId}",
+                    Memo = null,
+                },
+            };
+
+            AplosIntegrationService service = GetAplosIntegrationService();
+
+            //Act
+            bool wasSynced = service.WasPexTransactionSyncedToAplos(aplosTransactions, paymentRequestId);
+
+            //Assert
+            Assert.True(wasSynced);
+        }
+
+        [Fact]
+        public void WasPexTransactionSyncedToAplos_ReturnsTrue_WhenPaymentRequestIdIsOnlyNote()
+        {
+            //Arrange — reimbursement with no merchant/payee info
+            string paymentRequestId = "99999";
+
+            var aplosTransactions = new List<AplosApiTransactionDetail>
+            {
+                new AplosApiTransactionDetail
+                {
+                    Note = paymentRequestId,
+                    Memo = null,
+                },
+            };
+
+            AplosIntegrationService service = GetAplosIntegrationService();
+
+            //Act
+            bool wasSynced = service.WasPexTransactionSyncedToAplos(aplosTransactions, paymentRequestId);
+
+            //Assert
+            Assert.True(wasSynced);
+        }
+
+        [Fact]
+        public void WasPexTransactionSyncedToAplos_ReturnsFalse_WhenPaymentRequestIdNotPresent()
+        {
+            //Arrange
+            string paymentRequestId = "12345";
+
+            var aplosTransactions = new List<AplosApiTransactionDetail>
+            {
+                new AplosApiTransactionDetail
+                {
+                    Note = "Merchant | John Doe | 99999",
+                    Memo = null,
+                },
+            };
+
+            AplosIntegrationService service = GetAplosIntegrationService();
+
+            //Act
+            bool wasSynced = service.WasPexTransactionSyncedToAplos(aplosTransactions, paymentRequestId);
+
+            //Assert
+            Assert.False(wasSynced);
+        }
+
+        [Fact]
         public void WasPexTransactionSyncedToAplos_ReturnsTrue_WhenIdIsLastSegmentOfNote()
         {
             //Arrange - new note format "{ContactName} | {Notes} | {TransactionId}"
@@ -675,6 +747,159 @@ namespace AplosConnector.Common.Tests
             Assert.Equal("Resources (1002)", dedupedAccounts[1].Name);
             Assert.Equal("Travel", dedupedAccounts[2].Name);
             Assert.Equal("Resources (1004)", dedupedAccounts[3].Name);
+        }
+
+        [Theory]
+        [InlineData(0, 1, 1, "Contact not configured")]
+        [InlineData(1, 0, 1, "Fund not configured")]
+        [InlineData(1, 1, 0, "Account not configured")]
+        public void Pex2AplosMappingModel_SyncReimbursements_RequiresAllDefaults(
+            int contactId, int fundId, decimal accountNumber, string scenario)
+        {
+            //Arrange — verify the mapping model can hold reimbursement config
+            var mapping = new Pex2AplosMappingModel
+            {
+                SyncReimbursements = true,
+                ReimbursementsAplosContactId = contactId,
+                ReimbursementsAplosFundId = fundId,
+                ReimbursementsAplosTransactionAccountNumber = accountNumber,
+            };
+
+            //Act
+            bool isConfigured = mapping.ReimbursementsAplosContactId > 0
+                && mapping.ReimbursementsAplosFundId > 0
+                && mapping.ReimbursementsAplosTransactionAccountNumber > 0;
+
+            //Assert
+            Assert.False(isConfigured, $"Should not be fully configured when: {scenario}");
+        }
+
+        [Fact]
+        public void Pex2AplosMappingModel_SyncReimbursements_FlagDefaultsToFalse()
+        {
+            //Arrange & Act
+            var mapping = new Pex2AplosMappingModel();
+
+            //Assert
+            Assert.False(mapping.SyncReimbursements);
+        }
+
+        [Fact]
+        public void Pex2AplosMappingModel_ReimbursementSettings_RoundTripThroughStorageModel()
+        {
+            //Arrange
+            var mapping = new Pex2AplosMappingModel
+            {
+                SyncReimbursements = true,
+                SyncReimbursementsCreateContact = true,
+                ReimbursementsAplosContactId = 42,
+                ReimbursementsAplosFundId = 7,
+                ReimbursementsAplosTransactionAccountNumber = 5010,
+                ReimbursementsAplosTaxTagId = "990-1",
+                ReimbursementTagMappings = new[] { new AplosTagMappingModel { AplosTagId = "cat1", DefaultAplosTagValue = "val1" } },
+            };
+
+            //Act
+            var storageModel = mapping.ToStorageModel();
+
+            //Assert
+            Assert.True(storageModel.SyncReimbursements);
+            Assert.True(storageModel.SyncReimbursementsCreateContact);
+            Assert.Equal(42, storageModel.ReimbursementsAplosContactId);
+            Assert.Equal(7, storageModel.ReimbursementsAplosFundId);
+            Assert.Equal(5010, storageModel.ReimbursementsAplosTransactionAccountNumber);
+            Assert.Equal("990-1", storageModel.ReimbursementsAplosTaxTag);
+            Assert.NotNull(storageModel.ReimbursementTagMappings);
+            Assert.Single(storageModel.ReimbursementTagMappings);
+            Assert.Equal("cat1", storageModel.ReimbursementTagMappings[0].AplosTagId);
+        }
+
+        [Fact]
+        public void Pex2AplosMappingModel_UpdateFromSettings_PopulatesReimbursementFields()
+        {
+            //Arrange
+            var mapping = new Pex2AplosMappingModel();
+            var settings = mapping.ToStorageModel();
+            settings.SyncReimbursements = true;
+            settings.ReimbursementsAplosContactId = 10;
+            settings.ReimbursementsAplosFundId = 20;
+            settings.ReimbursementsAplosTransactionAccountNumber = 3000;
+            settings.ReimbursementsAplosTaxTag = "990-2";
+            settings.ReimbursementTagMappings = new[] { new AplosTagMappingModel { AplosTagId = "c2", DefaultAplosTagValue = "v2" } };
+
+            //Act
+            mapping.UpdateFromSettings(settings);
+
+            //Assert
+            Assert.True(mapping.SyncReimbursements);
+            Assert.Equal(10, mapping.ReimbursementsAplosContactId);
+            Assert.Equal(20, mapping.ReimbursementsAplosFundId);
+            Assert.Equal(3000, mapping.ReimbursementsAplosTransactionAccountNumber);
+            Assert.Equal("990-2", mapping.ReimbursementsAplosTaxTagId);
+            Assert.Single(mapping.ReimbursementTagMappings);
+        }
+
+        [Fact]
+        public void Pex2AplosMappingModel_SyncReimbursementsCreateContact_DefaultsToFalse()
+        {
+            var mapping = new Pex2AplosMappingModel();
+            Assert.False(mapping.SyncReimbursementsCreateContact);
+        }
+
+        [Fact]
+        public void Pex2AplosMappingModel_SyncReimbursementsCreateContact_RoundTripThroughStorageModel()
+        {
+            //Arrange
+            var mapping = new Pex2AplosMappingModel
+            {
+                SyncReimbursementsCreateContact = true,
+                ReimbursementsAplosContactId = 42,
+                ReimbursementsAplosFundId = 7,
+                ReimbursementsAplosTransactionAccountNumber = 5010,
+            };
+
+            //Act
+            var storageModel = mapping.ToStorageModel();
+
+            //Assert
+            Assert.True(storageModel.SyncReimbursementsCreateContact);
+        }
+
+        [Fact]
+        public void Pex2AplosMappingModel_UpdateFromSettings_PopulatesSyncReimbursementsCreateContact()
+        {
+            //Arrange
+            var mapping = new Pex2AplosMappingModel();
+            var settings = mapping.ToStorageModel();
+            settings.SyncReimbursementsCreateContact = true;
+
+            //Act
+            mapping.UpdateFromSettings(settings);
+
+            //Assert
+            Assert.True(mapping.SyncReimbursementsCreateContact);
+        }
+
+        [Fact]
+        public void Pex2AplosMappingModel_SyncReimbursements_ContactNotRequired_WhenCreateContactEnabled()
+        {
+            //Arrange
+            var mapping = new Pex2AplosMappingModel
+            {
+                SyncReimbursements = true,
+                SyncReimbursementsCreateContact = true,
+                ReimbursementsAplosContactId = 0,
+                ReimbursementsAplosFundId = 200,
+                ReimbursementsAplosTransactionAccountNumber = 5000,
+            };
+
+            //Act — mirrors the guard check in SyncReimbursements
+            bool isConfigured = (mapping.SyncReimbursementsCreateContact || mapping.ReimbursementsAplosContactId > 0)
+                && mapping.ReimbursementsAplosFundId > 0
+                && mapping.ReimbursementsAplosTransactionAccountNumber > 0;
+
+            //Assert
+            Assert.True(isConfigured, "Should be configured when SyncReimbursementsCreateContact is true even without a contact ID");
         }
 
         private AplosIntegrationService GetAplosIntegrationService()


### PR DESCRIPTION
## Summary

- Implements `SyncReimbursements` in `AplosIntegrationService`: fetches paid PEX reimbursements, maps them to Aplos double-entry transactions (credit register/bank, debit expense), records sync history, and is invoked from the `Sync` orchestration.
- Fetch mirrors the proven sibling connectors (QBO/Intacct/Blackbaud): `PaymentStatuses = [Pending, Closed]` + trigger set `[Settling, AwaitingOutboundCompletion, Settled, Returned, Cancelled]`, filtered by **outbound ACH creation date**.
- Posts **only fully-settled** reimbursements (payment trigger `== Settled`); Returned/Cancelled/in-flight are skipped and settle on a later run.
- Robust pagination + dedupe of transfers and payment requests to prevent in-run double-posting.
- Contact handling: single default contact, or auto-create a contact per employee.
- Amount signs verified against Aplos rules (transaction-level amount is a positive magnitude; direction lives in the line signs — asset negative, expense positive).

Work items: [AB#140665](https://pexcard.visualstudio.com/aeed64c4-c884-4a53-8682-73e24201472f/_workitems/edit/140665), [AB#140666](https://pexcard.visualstudio.com/aeed64c4-c884-4a53-8682-73e24201472f/_workitems/edit/140666), [AB#140667](https://pexcard.visualstudio.com/aeed64c4-c884-4a53-8682-73e24201472f/_workitems/edit/140667), [AB#140668](https://pexcard.visualstudio.com/aeed64c4-c884-4a53-8682-73e24201472f/_workitems/edit/140668)

## Notes for reviewers

- **Dedup method:** this branch was cut before PR #258 merged; the whole-file move initially reverted the delimiter-aware `WasPexTransactionSyncedToAplos` fix (work item 138157). Restored to master's version and re-added its collision-guard tests, so this PR does **not** touch that method's behavior.
- **Amount sign investigation:** confirmed with the DEVIN + Aplos API docs/UI that the transaction header amount must be ≥ 0 (positive magnitude); the existing line signs already encode the outflow correctly, so no sign change was needed.
- **Known follow-ups (not in this PR):** unit tests directly exercising the constructed `AplosApiTransactionDetail` (line signs, contact selection, note format) and the Settled filter; a per-run contact cache; invariant-culture decimal handling shared across all account-number fields.

---

<sub>Co-authored with Claude Code (model: claude-opus-4-8)</sub>