### PR TITLE
143012 Aplos Reimbursements: independent toggle, contact options, shared mapping, bank account

### DIFF
--- a/src/AplosConnector.Common/Entities/Pex2AplosMappingEntity.cs
+++ b/src/AplosConnector.Common/Entities/Pex2AplosMappingEntity.cs
@@ -72,16 +72,13 @@ namespace AplosConnector.Common.Entities
 
         public bool SyncReimbursementsCreateContact { get; set; }
         public int ReimbursementsAplosContactId { get; set; }
-        public int ReimbursementsAplosFundId { get; set; }
-        public string ReimbursementsAplosTransactionAccountNumber { get; set; }
-        public string ReimbursementsAplosTaxTagId { get; set; }
+        public string ReimbursementsAplosRegisterAccountNumber { get; set; }
 
         public string ExpenseAccountMappings { get; set; }
         public string TagMappings { get; set; }
         public string TransferTagMappings { get; set; }
         public string FeeTagMappings { get; set; }
         public string RebateTagMappings { get; set; }
-        public string ReimbursementTagMappings { get; set; }
         
         public string PEXEmailAccount { get; set; }
         public string PEXNameAccount { get; set; }

--- a/src/AplosConnector.Common/Models/MappingSettingsModel.cs
+++ b/src/AplosConnector.Common/Models/MappingSettingsModel.cs
@@ -91,16 +91,13 @@ namespace AplosConnector.Common.Models
 
         public bool SyncReimbursementsCreateContact { get; set; }
         public int ReimbursementsAplosContactId { get; set; }
-        public int ReimbursementsAplosFundId { get; set; }
-        public decimal ReimbursementsAplosTransactionAccountNumber { get; set; }
-        public string ReimbursementsAplosTaxTag { get; set; }
+        public decimal ReimbursementsAplosRegisterAccountNumber { get; set; }
 
         public ExpenseAccountMappingModel[] ExpenseAccountMappings { get; set; }
         public TagMappingModel[] TagMappings { get; set; }
         public AplosTagMappingModel[] TransferTagMappings { get; set; }
         public AplosTagMappingModel[] FeeTagMappings { get; set; }
         public AplosTagMappingModel[] RebateTagMappings { get; set; }
-        public AplosTagMappingModel[] ReimbursementTagMappings { get; set; }
         public FundingSource PEXFundingSource { get; set; }
 
         public double? SyncTransactionsIntervalDays { get; set; }

--- a/src/AplosConnector.Common/Models/Pex2AplosMappingModel.cs
+++ b/src/AplosConnector.Common/Models/Pex2AplosMappingModel.cs
@@ -67,9 +67,7 @@ namespace AplosConnector.Common.Models
 
             SyncReimbursementsCreateContact = mapping.SyncReimbursementsCreateContact;
             ReimbursementsAplosContactId = mapping.ReimbursementsAplosContactId;
-            ReimbursementsAplosFundId = mapping.ReimbursementsAplosFundId;
-            ReimbursementsAplosTransactionAccountNumber = mapping.ReimbursementsAplosTransactionAccountNumber;
-            ReimbursementsAplosTaxTagId = mapping.ReimbursementsAplosTaxTag;
+            ReimbursementsAplosRegisterAccountNumber = mapping.ReimbursementsAplosRegisterAccountNumber;
 
             PexFundsTagId = mapping.PexFundsTagId;
             SyncFundsToPex = mapping.SyncFundsToPex;
@@ -81,7 +79,6 @@ namespace AplosConnector.Common.Models
             TransferTagMappings = mapping.TransferTagMappings;
             FeeTagMappings = mapping.FeeTagMappings;
             RebateTagMappings = mapping.RebateTagMappings;
-            ReimbursementTagMappings = mapping.ReimbursementTagMappings;
             PEXFundingSource = mapping.PEXFundingSource;
             MapVendorCards = mapping.MapVendorCards;
             UseNormalizedMerchantNames = mapping.UseNormalizedMerchantNames;
@@ -157,9 +154,7 @@ namespace AplosConnector.Common.Models
 
                 SyncReimbursementsCreateContact = SyncReimbursementsCreateContact,
                 ReimbursementsAplosContactId = ReimbursementsAplosContactId,
-                ReimbursementsAplosFundId = ReimbursementsAplosFundId,
-                ReimbursementsAplosTransactionAccountNumber = ReimbursementsAplosTransactionAccountNumber,
-                ReimbursementsAplosTaxTag = ReimbursementsAplosTaxTagId,
+                ReimbursementsAplosRegisterAccountNumber = ReimbursementsAplosRegisterAccountNumber,
 
                 SyncFundsToPex = SyncFundsToPex,
 
@@ -168,7 +163,6 @@ namespace AplosConnector.Common.Models
                 TransferTagMappings = TransferTagMappings,
                 FeeTagMappings = FeeTagMappings,
                 RebateTagMappings = RebateTagMappings,
-                ReimbursementTagMappings = ReimbursementTagMappings,
                 PEXFundingSource = PEXFundingSource,
 
                 SyncTransactionsIntervalDays = SyncTransactionsIntervalDays,
@@ -240,16 +234,13 @@ namespace AplosConnector.Common.Models
 
         public bool SyncReimbursementsCreateContact { get; set; }
         public int ReimbursementsAplosContactId { get; set; }
-        public int ReimbursementsAplosFundId { get; set; }
-        public decimal ReimbursementsAplosTransactionAccountNumber { get; set; }
-        public string ReimbursementsAplosTaxTagId { get; set; }
+        public decimal ReimbursementsAplosRegisterAccountNumber { get; set; }
 
         public ExpenseAccountMappingModel[] ExpenseAccountMappings { get; set; }
         public TagMappingModel[] TagMappings { get; set; }
         public AplosTagMappingModel[] TransferTagMappings { get; set; }
         public AplosTagMappingModel[] FeeTagMappings { get; set; }
         public AplosTagMappingModel[] RebateTagMappings { get; set; }
-        public AplosTagMappingModel[] ReimbursementTagMappings { get; set; }
 
         public string PEXEmailAccount { get; set; }
         public string PEXNameAccount { get; set; }

--- a/src/AplosConnector.Common/Services/AplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/AplosIntegrationService.cs
@@ -1162,8 +1162,11 @@ namespace AplosConnector.Common.Services
                                         {
                                             if (tagMapping.AplosTagId == "990")
                                             {
-                                                _logger.LogInformation($"Using default Aplos tax tag value '{tagMapping.DefaultAplosTagId}' on transaction {transaction.TransactionId}.");
-                                                pexTagValues.AplosTaxTagId = tagMapping.DefaultAplosTagId;
+                                                if (mapping.SyncTaxTagToPex)
+                                                {
+                                                    _logger.LogInformation($"Using default Aplos tax tag value '{tagMapping.DefaultAplosTagId}' on transaction {transaction.TransactionId}.");
+                                                    pexTagValues.AplosTaxTagId = tagMapping.DefaultAplosTagId;
+                                                }
                                             }
                                             else
                                             {
@@ -1202,11 +1205,14 @@ namespace AplosConnector.Common.Services
                                         _logger.LogInformation($"No Aplos tag mappings to process.");
                                     }
 
-                                    var taxTag = allocation.GetTagValue(mapping.PexTaxTagId);
-                                    if (taxTag != null && taxTag.Value != null)
+                                    if (mapping.SyncTaxTagToPex)
                                     {
-                                        _logger.LogInformation($"Using transaction tag {mapping.PexTaxTagId} for transaction {transaction.TransactionId} as Aplos tax tag value '{taxTag.Value}'.");
-                                        pexTagValues.AplosTaxTagId = taxTag.Value.ToString();
+                                        var taxTag = allocation.GetTagValue(mapping.PexTaxTagId);
+                                        if (taxTag != null && taxTag.Value != null)
+                                        {
+                                            _logger.LogInformation($"Using transaction tag {mapping.PexTaxTagId} for transaction {transaction.TransactionId} as Aplos tax tag value '{taxTag.Value}'.");
+                                            pexTagValues.AplosTaxTagId = taxTag.Value.ToString();
+                                        }
                                     }
                                 }
                                 else
@@ -1427,7 +1433,7 @@ namespace AplosConnector.Common.Services
                                 AplosRegisterAccountNumber = mapping.AplosRegisterAccountNumber,
                                 AplosContactId = mapping.PexRebatesAplosContactId,
                                 AplosFundId = mapping.PexRebatesAplosFundId,
-                                AplosTaxTagId = mapping.PexRebatesAplosTaxTagId,
+                                AplosTaxTagId = mapping.SyncTaxTagToPex ? mapping.PexRebatesAplosTaxTagId : null,
                                 AplosTransactionAccountNumber = mapping.PexRebatesAplosTransactionAccountNumber
                             };
 
@@ -1692,7 +1698,7 @@ namespace AplosConnector.Common.Services
                 };
                 var nonCashTagValues = new PexTagValuesModel
                 {
-                    AplosTaxTagId = mapping.PexRebatesAplosTaxTagId
+                    AplosTaxTagId = mapping.SyncTaxTagToPex ? mapping.PexRebatesAplosTaxTagId : null
                 };
                 ApplyTagMappingsToTagValues(nonCashTagValues, mapping.RebateTagMappings, logger);
                 ApplyTagsToLine(nonCashCreditLine, nonCashTagValues);
@@ -1863,7 +1869,7 @@ namespace AplosConnector.Common.Services
                     };
                     var checkingOffsetTagValues = new PexTagValuesModel
                     {
-                        AplosTaxTagId = mapping.PexRebatesAplosTaxTagId
+                        AplosTaxTagId = mapping.SyncTaxTagToPex ? mapping.PexRebatesAplosTaxTagId : null
                     };
                     ApplyTagMappingsToTagValues(checkingOffsetTagValues, mapping.RebateTagMappings, logger);
                     ApplyTagsToLine(checkingOffsetLine, checkingOffsetTagValues);
@@ -2026,7 +2032,7 @@ namespace AplosConnector.Common.Services
                     };
                     var rebateTagValues = new PexTagValuesModel
                     {
-                        AplosTaxTagId = mapping.PexRebatesAplosTaxTagId
+                        AplosTaxTagId = mapping.SyncTaxTagToPex ? mapping.PexRebatesAplosTaxTagId : null
                     };
                     ApplyTagMappingsToTagValues(rebateTagValues, mapping.RebateTagMappings, logger);
                     ApplyTagsToLine(rebateIncomeLine, rebateTagValues);
@@ -2232,7 +2238,7 @@ namespace AplosConnector.Common.Services
                                 AplosRegisterAccountNumber = model.AplosRegisterAccountNumber,
                                 AplosContactId = model.PexFeesAplosContactId,
                                 AplosFundId = model.PexFeesAplosFundId,
-                                AplosTaxTagId = model.PexFeesAplosTaxTagId,
+                                AplosTaxTagId = model.SyncTaxTagToPex ? model.PexFeesAplosTaxTagId : null,
                                 AplosTransactionAccountNumber = model.PexFeesAplosTransactionAccountNumber
                             };
 
@@ -2537,9 +2543,24 @@ namespace AplosConnector.Common.Services
         {
             if (!mapping.SyncReimbursements) return;
 
+            // Reimbursements share the purchases mapping configuration (the "Purchases and
+            // Reimbursements" wizard page): fund, expense account, category tags, and 990
+            // resolve from the shared mappings and their defaults.
+            var defaultReimbursementsFundId = mapping.DefaultAplosFundId;
+            var defaultReimbursementsAccountNumber = mapping.ExpenseAccountMappings?.FirstOrDefault(m => m.DefaultAplosTransactionAccountNumber > 0)?.DefaultAplosTransactionAccountNumber ?? 0;
+            if (defaultReimbursementsAccountNumber <= 0)
+            {
+                defaultReimbursementsAccountNumber = mapping.DefaultAplosTransactionAccountNumber;
+            }
+
+            var hasFundConfig = defaultReimbursementsFundId > 0 || !string.IsNullOrEmpty(mapping.PexFundsTagId);
+            var hasAccountConfig = defaultReimbursementsAccountNumber > 0
+                || mapping.ExpenseAccountMappings?.Any(m => !string.IsNullOrEmpty(m.ExpenseAccountsPexTagId)) == true;
+
             if (!(mapping.SyncReimbursementsCreateContact || mapping.ReimbursementsAplosContactId > 0)
-                || mapping.ReimbursementsAplosFundId <= 0
-                || mapping.ReimbursementsAplosTransactionAccountNumber <= 0)
+                || mapping.ReimbursementsAplosRegisterAccountNumber <= 0
+                || !hasFundConfig
+                || !hasAccountConfig)
             {
                 logger.LogInformation($"Skipping sync reimbursements for business {mapping.PEXBusinessAcctId}. Reimbursements are not configured.");
                 return;
@@ -2562,6 +2583,14 @@ namespace AplosConnector.Common.Services
             var aplosAccountCategory = GetAplosAccountCategory();
             var aplosExpenseAccounts = (await GetAplosAccounts(mapping, aplosAccountCategory, cancellationToken)).ToList();
 
+            // Flattened Aplos tag values are only needed for per-request category tag
+            // resolution, which requires configured tag mappings.
+            List<PexAplosApiObject> aplosTags = default;
+            if (mapping.TagMappings?.Any() == true)
+            {
+                aplosTags = (await GetFlattenedAplosTagValues(mapping, cancellationToken)).ToList();
+            }
+
             // Fetch PEX dropdown tag definitions for tag answer resolution
             var useTags = await _pexApiClient.IsTagsAvailable(mapping.PEXExternalAPIToken, CustomFieldType.Dropdown, cancellationToken);
             List<TagDropdownDetailsModel> dropdownTags = default;
@@ -2577,6 +2606,7 @@ namespace AplosConnector.Common.Services
                 {
                     foreach (var expenseAccountMapping in mapping.ExpenseAccountMappings)
                     {
+                        if (string.IsNullOrEmpty(expenseAccountMapping.ExpenseAccountsPexTagId)) continue;
                         dropdownTagTasks.Add(_pexApiClient.GetDropdownTag(mapping.PEXExternalAPIToken, expenseAccountMapping.ExpenseAccountsPexTagId, true, cancellationToken));
                     }
                 }
@@ -2584,6 +2614,7 @@ namespace AplosConnector.Common.Services
                 {
                     foreach (var tagMapping in mapping.TagMappings)
                     {
+                        if (string.IsNullOrEmpty(tagMapping.PexTagId)) continue;
                         dropdownTagTasks.Add(_pexApiClient.GetDropdownTag(mapping.PEXExternalAPIToken, tagMapping.PexTagId, true, cancellationToken));
                     }
                 }
@@ -2707,21 +2738,63 @@ namespace AplosConnector.Common.Services
                     {
                         var pexTagValues = new PexTagValuesModel
                         {
-                            AplosRegisterAccountNumber = mapping.AplosRegisterAccountNumber,
+                            // Reimbursements are paid out of the org's bank account, not the PEX
+                            // register — the register line always uses the reimbursement bank account.
+                            AplosRegisterAccountNumber = mapping.ReimbursementsAplosRegisterAccountNumber,
                             AplosContactId = mapping.ReimbursementsAplosContactId,
-                            AplosFundId = mapping.ReimbursementsAplosFundId,
-                            AplosTaxTagId = mapping.ReimbursementsAplosTaxTagId,
-                            AplosTransactionAccountNumber = mapping.ReimbursementsAplosTransactionAccountNumber,
+                            AplosFundId = defaultReimbursementsFundId,
+                            AplosTransactionAccountNumber = defaultReimbursementsAccountNumber,
                         };
 
-                        // Apply reimbursement default Aplos tags. Reimbursement category tags
-                        // (Fundraisers/Projects/Departments/Custom) are configured in
-                        // ReimbursementTagMappings, not TagMappings. Apply them unconditionally,
-                        // consistent with how transfers/fees/rebates apply their own *TagMappings.
-                        ApplyTagMappingsToTagValues(pexTagValues, mapping.ReimbursementTagMappings, logger);
+                        var tagAnswers = pr.Metadata?.TagAnswers;
+
+                        if (mapping.TagMappings?.Any() == true)
+                        {
+                            // Resolve category tags (Fundraisers/Projects/Departments/Custom/990) from the
+                            // reimbursement's PEX tag answers using the shared tag mappings, falling back
+                            // to each mapping's default — mirrors the purchases sync.
+                            pexTagValues.AplosTagIds = new List<string>();
+
+                            foreach (var tagMapping in mapping.TagMappings)
+                            {
+                                if (tagMapping.AplosTagId == "990")
+                                {
+                                    if (mapping.SyncTaxTagToPex && !string.IsNullOrEmpty(tagMapping.DefaultAplosTagId))
+                                    {
+                                        logger.LogInformation($"Using default Aplos tax tag value '{tagMapping.DefaultAplosTagId}' on reimbursement {pr.PaymentRequestId}.");
+                                        pexTagValues.AplosTaxTagId = tagMapping.DefaultAplosTagId;
+                                    }
+                                    continue;
+                                }
+
+                                var categoryTagAnswer = useTags ? GetReimbursementTagAnswer(tagAnswers, tagMapping.PexTagId) : null;
+                                // Mirror the purchases loop: the 990 tag answer is handled separately
+                                // below and must not be matched as a category tag.
+                                if (categoryTagAnswer != null
+                                    && !string.Equals(categoryTagAnswer.FieldId, mapping.PexTaxTagId, StringComparison.InvariantCultureIgnoreCase))
+                                {
+                                    var categoryTagValueItem = new TagValueItem { TagId = categoryTagAnswer.FieldId, Value = categoryTagAnswer.Value };
+                                    var categoryTagDefinition = dropdownTags?.FirstOrDefault(t => t.Id.Equals(categoryTagAnswer.FieldId, StringComparison.InvariantCultureIgnoreCase));
+                                    var categoryTagOptionValue = categoryTagAnswer.Value?.ToString();
+                                    var categoryTagOptionName = categoryTagValueItem.GetTagOptionName(categoryTagDefinition?.Options);
+                                    var categoryTagEntity = aplosTags.FindMatchingEntity(categoryTagOptionValue, categoryTagOptionName, ':', logger);
+                                    if (categoryTagEntity != null)
+                                    {
+                                        logger.LogDebug($"Matched PEX tag '{categoryTagDefinition?.Name}' option ['{categoryTagOptionName}' : '{categoryTagOptionValue}'] with Aplos tag '{categoryTagEntity.Name}' ({categoryTagEntity.Id}) on reimbursement {pr.PaymentRequestId}.");
+                                        pexTagValues.AplosTagIds.Add(categoryTagEntity.Id);
+                                        continue;
+                                    }
+                                }
+
+                                if (!string.IsNullOrEmpty(tagMapping.DefaultAplosTagId))
+                                {
+                                    logger.LogInformation($"Using default Aplos tag value '{tagMapping.DefaultAplosTagId}' on reimbursement {pr.PaymentRequestId}.");
+                                    pexTagValues.AplosTagIds.Add(tagMapping.DefaultAplosTagId);
+                                }
+                            }
+                        }
 
                         // Resolve fund, expense account, and tax tag dynamically from PEX tag answers if available
-                        var tagAnswers = pr.Metadata?.TagAnswers;
                         if (useTags && tagAnswers != null)
                         {
                             // Resolve fund from tag answers
@@ -2740,7 +2813,7 @@ namespace AplosConnector.Common.Services
                                 }
                                 else
                                 {
-                                    logger.LogInformation($"Could not match fund tag on reimbursement {pr.PaymentRequestId}. Using default fund {mapping.ReimbursementsAplosFundId}.");
+                                    logger.LogInformation($"Could not match fund tag on reimbursement {pr.PaymentRequestId}. Using default fund {defaultReimbursementsFundId}.");
                                 }
                             }
 
@@ -2779,7 +2852,7 @@ namespace AplosConnector.Common.Services
                                     }
                                     else
                                     {
-                                        logger.LogInformation($"Could not match expense account tag on reimbursement {pr.PaymentRequestId}. Using default account {mapping.ReimbursementsAplosTransactionAccountNumber}.");
+                                        logger.LogInformation($"Could not match expense account tag on reimbursement {pr.PaymentRequestId}. Using default account {defaultReimbursementsAccountNumber}.");
                                     }
                                 }
                                 else if (defaultAccountNumber > 0)
@@ -2789,15 +2862,29 @@ namespace AplosConnector.Common.Services
                             }
 
                             // Resolve 990 tax tag from tag answers
-                            var taxTagAnswer = GetReimbursementTagAnswer(tagAnswers, mapping.PexTaxTagId);
-                            if (taxTagAnswer?.Value != null)
+                            if (mapping.SyncTaxTagToPex)
                             {
-                                logger.LogInformation($"Using reimbursement tag {mapping.PexTaxTagId} for reimbursement {pr.PaymentRequestId} as Aplos tax tag value '{taxTagAnswer.Value}'.");
-                                pexTagValues.AplosTaxTagId = taxTagAnswer.Value.ToString();
+                                var taxTagAnswer = GetReimbursementTagAnswer(tagAnswers, mapping.PexTaxTagId);
+                                if (taxTagAnswer?.Value != null)
+                                {
+                                    logger.LogInformation($"Using reimbursement tag {mapping.PexTaxTagId} for reimbursement {pr.PaymentRequestId} as Aplos tax tag value '{taxTagAnswer.Value}'.");
+                                    pexTagValues.AplosTaxTagId = taxTagAnswer.Value.ToString();
+                                }
                             }
                         }
 
                         // Build double-entry lines
+                        // With a tag-only configuration (no defaults) an untagged or unmatched
+                        // reimbursement can end up without a resolved fund or expense account.
+                        // Posting Id/AccountNumber = 0 would create a broken entry in Aplos, so
+                        // count it as a failure and surface the misconfiguration in the sync status.
+                        if (pexTagValues.AplosFundId <= 0 || pexTagValues.AplosTransactionAccountNumber <= 0)
+                        {
+                            failureCount++;
+                            logger.LogWarning($"Skipping reimbursement {pr.PaymentRequestId} for business {mapping.PEXBusinessAcctId}. Could not resolve a fund ({pexTagValues.AplosFundId}) or expense account ({pexTagValues.AplosTransactionAccountNumber}) from tag answers and no default is configured.");
+                            continue;
+                        }
+
                         var amount = pr.Amount;
 
                         var registerLine = new AplosApiTransactionLineDetail
@@ -2814,7 +2901,7 @@ namespace AplosConnector.Common.Services
                             Fund = new AplosApiFundDetail { Id = pexTagValues.AplosFundId },
                         };
 
-                        if (pexTagValues.AplosTagIds != null)
+                        if (pexTagValues.AplosTagIds?.Count > 0)
                         {
                             expenseLine.Tags = new List<AplosApiTagDetail>();
                             foreach (var aplosTagId in pexTagValues.AplosTagIds)
@@ -2880,17 +2967,12 @@ namespace AplosConnector.Common.Services
                             {
                                 contact = new AplosApiContactDetail { CompanyName = payeeName, Type = "individual" };
                             }
-                            else if (pexTagValues.AplosContactId > 0)
-                            {
-                                contact = new AplosApiContactDetail { Id = pexTagValues.AplosContactId };
-                            }
                             else
                             {
-                                // Create-contact mode with a blank employee name and no fallback contact configured.
-                                // Count as a failure (not a silent skip) so the misconfiguration surfaces in the sync
-                                // status, matching how SyncTransactions/SyncInvoices treat ineligible-but-expected records.
+                                // Create-contact mode with a blank employee name. Count as a failure
+                                // (not a silent skip) so the anomaly surfaces in the sync status.
                                 failureCount++;
-                                logger.LogWarning($"Skipping reimbursement {pr.PaymentRequestId} for business {mapping.PEXBusinessAcctId}. Auto-create contact is enabled but the payee name is empty and no default contact is configured.");
+                                logger.LogWarning($"Skipping reimbursement {pr.PaymentRequestId} for business {mapping.PEXBusinessAcctId}. Auto-create contact is enabled but the payee name is empty.");
                                 continue;
                             }
                         }

--- a/src/AplosConnector.Common/Services/StorageMappingService.cs
+++ b/src/AplosConnector.Common/Services/StorageMappingService.cs
@@ -97,9 +97,7 @@ namespace AplosConnector.Common.Services
 
                     SyncReimbursementsCreateContact = model.SyncReimbursementsCreateContact,
                     ReimbursementsAplosContactId = model.ReimbursementsAplosContactId,
-                    ReimbursementsAplosFundId = model.ReimbursementsAplosFundId,
-                    ReimbursementsAplosTransactionAccountNumber = model.ReimbursementsAplosTransactionAccountNumber.ToString(),
-                    ReimbursementsAplosTaxTagId = model.ReimbursementsAplosTaxTagId,
+                    ReimbursementsAplosRegisterAccountNumber = model.ReimbursementsAplosRegisterAccountNumber.ToString(),
 
                     PexFundsTagId = model.PexFundsTagId,
                     SyncFundsToPex = model.SyncFundsToPex,
@@ -109,7 +107,6 @@ namespace AplosConnector.Common.Services
                     TransferTagMappings = JsonConvert.SerializeObject(model.TransferTagMappings),
                     FeeTagMappings = JsonConvert.SerializeObject(model.FeeTagMappings),
                     RebateTagMappings = JsonConvert.SerializeObject(model.RebateTagMappings),
-                    ReimbursementTagMappings = JsonConvert.SerializeObject(model.ReimbursementTagMappings),
 
                     PexTaxTagId = model.PexTaxTagId,
 
@@ -178,7 +175,7 @@ namespace AplosConnector.Common.Services
                 decimal.TryParse(model.TransfersAplosTransactionAccountNumber, out var transfersAplosTransactionAccountNumber);
                 decimal.TryParse(model.PexFeesAplosTransactionAccountNumber, out var pexFeesAplosTransactionAccountNumber);
                 decimal.TryParse(model.PexRebatesAplosTransactionAccountNumber, out var pexRebatesAplosTransactionAccountNumber);
-                decimal.TryParse(model.ReimbursementsAplosTransactionAccountNumber, out var reimbursementsAplosTransactionAccountNumber);
+                decimal.TryParse(model.ReimbursementsAplosRegisterAccountNumber, out var reimbursementsAplosRegisterAccountNumber);
 
                 result = new Pex2AplosMappingModel
                 {
@@ -236,9 +233,7 @@ namespace AplosConnector.Common.Services
 
                     SyncReimbursementsCreateContact = model.SyncReimbursementsCreateContact,
                     ReimbursementsAplosContactId = model.ReimbursementsAplosContactId,
-                    ReimbursementsAplosFundId = model.ReimbursementsAplosFundId,
-                    ReimbursementsAplosTransactionAccountNumber = reimbursementsAplosTransactionAccountNumber,
-                    ReimbursementsAplosTaxTagId = model.ReimbursementsAplosTaxTagId,
+                    ReimbursementsAplosRegisterAccountNumber = reimbursementsAplosRegisterAccountNumber,
 
                     PexFundsTagId = model.PexFundsTagId,
                     SyncFundsToPex = model.SyncFundsToPex,
@@ -265,10 +260,6 @@ namespace AplosConnector.Common.Services
                     RebateTagMappings = model.RebateTagMappings == null
                         ? null
                         : JsonConvert.DeserializeObject<AplosTagMappingModel[]>(model.RebateTagMappings),
-
-                    ReimbursementTagMappings = model.ReimbursementTagMappings == null
-                        ? null
-                        : JsonConvert.DeserializeObject<AplosTagMappingModel[]>(model.ReimbursementTagMappings),
 
                     PexTaxTagId = model.PexTaxTagId,
 

--- a/src/AplosConnector.Web/ClientApp/src/app/services/mapping.service.ts
+++ b/src/AplosConnector.Web/ClientApp/src/app/services/mapping.service.ts
@@ -128,9 +128,7 @@ export interface SettingsModel {
 
   syncReimbursementsCreateContact: boolean;
   reimbursementsAplosContactId: number;
-  reimbursementsAplosFundId: number;
-  reimbursementsAplosTransactionAccountNumber: number;
-  reimbursementsAplosTaxTag: string;
+  reimbursementsAplosRegisterAccountNumber: number;
 
   aplosRegisterAccountNumber: number;
 
@@ -164,7 +162,6 @@ export interface SettingsModel {
   transferTagMappings: AplosTagMappingModel[];
   feeTagMappings: AplosTagMappingModel[];
   rebateTagMappings: AplosTagMappingModel[];
-  reimbursementTagMappings: AplosTagMappingModel[];
   syncInvoicesMethod: SyncInvoicesMethod;
 }
 

--- a/src/AplosConnector.Web/ClientApp/src/app/sync-connect/sync-connect.component.html
+++ b/src/AplosConnector.Web/ClientApp/src/app/sync-connect/sync-connect.component.html
@@ -135,7 +135,7 @@
     (clrWizardPageOnCommit)="onSettingsCommit()"
     (clrWizardPageOnCancel)="onCloseWizard()"
     [clrWizardPageNextDisabled]="!optionsForm.valid
-                   || ((settingsModel.syncTransactions || settingsModel.syncTransfers || settingsModel.syncInvoices || settingsModel.syncPexFees || settingsModel.syncReimbursements) && !settingsModel.aplosRegisterAccountNumber)
+                   || ((settingsModel.syncTransactions || settingsModel.syncTransfers || settingsModel.syncInvoices || settingsModel.syncPexFees) && !settingsModel.aplosRegisterAccountNumber)
                    || ((settingsModel.syncTransactions || settingsModel.syncTransfers || settingsModel.syncInvoices || settingsModel.syncPexFees || settingsModel.syncReimbursements) && !settingsModel.earliestTransactionDateToSync)">
 
     <ng-template clrPageNavTitle>Sync Selection</ng-template>
@@ -246,7 +246,7 @@
         <label>Automatically import bill payments and rebates into Aplos.</label>
       </clr-toggle-wrapper>
 
-      <clr-toggle-wrapper *ngIf="settingsModel.syncTransactions">
+      <clr-toggle-wrapper>
         <input
           type="checkbox"
           clrToggle
@@ -276,7 +276,9 @@
 
       <hr *ngIf="settingsModel.syncTransactions || settingsModel.syncTransfers || settingsModel.syncInvoices || settingsModel.syncPexFees || settingsModel.syncReimbursements" />
 
-      <div class="card" *ngIf="settingsModel.syncTransactions || settingsModel.syncTransfers || settingsModel.syncInvoices || settingsModel.syncPexFees || settingsModel.syncReimbursements">
+      <!-- Reimbursements don't use the PEX register account — their cash side is the
+           reimbursements Bank Account on Other Options. -->
+      <div class="card" *ngIf="settingsModel.syncTransactions || settingsModel.syncTransfers || settingsModel.syncInvoices || settingsModel.syncPexFees">
         <div class="card-block">
           <app-loading-placeholder
             [loadingState]="loadingAplosAccounts"
@@ -346,8 +348,9 @@
 
   </clr-wizard-page>
 
-  <clr-wizard-page *ngIf="isPexAccountLinked && aplosAuthenticationStatus?.hasAplosAccountId && (settingsModel?.syncTransactions || settingsModel?.syncInvoices)"
-                   [clrWizardPageNextDisabled]="!settingsModel.syncTransactionsCreateContact && !(settingsModel.defaultAplosContactId > 0)"
+  <clr-wizard-page *ngIf="isPexAccountLinked && aplosAuthenticationStatus?.hasAplosAccountId && (settingsModel?.syncTransactions || settingsModel?.syncInvoices || settingsModel?.syncReimbursements)"
+                   [clrWizardPageNextDisabled]="((settingsModel.syncTransactions || settingsModel.syncInvoices) && !settingsModel.syncTransactionsCreateContact && !(settingsModel.defaultAplosContactId > 0))
+                     || (settingsModel.syncReimbursements && !settingsModel.syncReimbursementsCreateContact && !(settingsModel.reimbursementsAplosContactId > 0))"
                    (clrWizardPageOnCommit)="onVendorCommit()">
 
     <ng-template clrPageNavTitle>Contact Options</ng-template>
@@ -356,34 +359,62 @@
     <app-loading-placeholder *ngIf="loadingAplosContacts" [loadingState]="loadingAplosContacts" [errorState]="errorLoadingAplosContacts" (retry)="getContacts()"></app-loading-placeholder>
 
     <form clrForm #vendorForm="ngForm" [class.hide]="!savingSettings || loadingVendors">
-      <clr-radio-container>
-        <clr-radio-wrapper>
-          <input type="radio" clrRadio required name="syncTransactionsCreateContact" [value]="false" [(ngModel)]="settingsModel.syncTransactionsCreateContact" />
-          <label>
-            <span>Use a single contact for your expenses </span>
-            <div *ngIf="!settingsModel.syncTransactionsCreateContact" class="clr-select-wrapper">
-              <select id="select-full-vendor"
-                      class="clr-select"
-                      name="defaultAplosContactId"
-                      [(ngModel)]="settingsModel.defaultAplosContactId">
-                <option [value]="vendor.id" *ngFor="let vendor of aplosContacts">{{vendor.name}}</option>
-              </select>
-            </div>
-          </label>
-        </clr-radio-wrapper>
-        <clr-radio-wrapper>
-          <input type="radio" clrRadio required name="syncTransactionsCreateContact" [value]="true" [(ngModel)]="settingsModel.syncTransactionsCreateContact" />
-          <label>Create a contact for each unique merchant</label>
-        </clr-radio-wrapper>
-        <clr-control-helper *ngIf="!settingsModel.syncTransactionsCreateContact" class="single-vendor-help"><strong>Tip:</strong> Consider creating a new contact in Aplos called 'PEX' to book PEX purchases with a single contact</clr-control-helper>
-      </clr-radio-container>
-      <clr-checkbox-container *ngIf="settingsModel.syncTransactionsCreateContact" class="normalized-vendors">
-        <clr-checkbox-wrapper>
-          <input type="checkbox" clrCheckbox name="useNormalizedMerchantNames" [value]="true" [(ngModel)]="settingsModel.useNormalizedMerchantNames" />
-          <label>Use standardized merchant names</label>
-        </clr-checkbox-wrapper>
-        <clr-control-helper class="normalized-vendors-help"><strong>Example:</strong> "Target" instead of "Target #0973226"</clr-control-helper>
-      </clr-checkbox-container>
+      <div *ngIf="settingsModel.syncTransactions || settingsModel.syncInvoices">
+        <h5>Purchases</h5>
+        <clr-radio-container>
+          <clr-radio-wrapper>
+            <input type="radio" clrRadio required name="syncTransactionsCreateContact" [value]="false" [(ngModel)]="settingsModel.syncTransactionsCreateContact" />
+            <label>
+              <span>Use a single contact for your expenses </span>
+              <div *ngIf="!settingsModel.syncTransactionsCreateContact" class="clr-select-wrapper">
+                <select id="select-full-vendor"
+                        class="clr-select"
+                        name="defaultAplosContactId"
+                        [(ngModel)]="settingsModel.defaultAplosContactId">
+                  <option [value]="vendor.id" *ngFor="let vendor of aplosContacts">{{vendor.name}}</option>
+                </select>
+              </div>
+            </label>
+          </clr-radio-wrapper>
+          <clr-radio-wrapper>
+            <input type="radio" clrRadio required name="syncTransactionsCreateContact" [value]="true" [(ngModel)]="settingsModel.syncTransactionsCreateContact" />
+            <label>Create a contact for each unique merchant</label>
+          </clr-radio-wrapper>
+          <clr-control-helper *ngIf="!settingsModel.syncTransactionsCreateContact" class="single-vendor-help"><strong>Tip:</strong> Consider creating a new contact in Aplos called 'PEX' to book PEX purchases with a single contact</clr-control-helper>
+        </clr-radio-container>
+        <clr-checkbox-container *ngIf="settingsModel.syncTransactionsCreateContact" class="normalized-vendors">
+          <clr-checkbox-wrapper>
+            <input type="checkbox" clrCheckbox name="useNormalizedMerchantNames" [value]="true" [(ngModel)]="settingsModel.useNormalizedMerchantNames" />
+            <label>Use standardized merchant names</label>
+          </clr-checkbox-wrapper>
+          <clr-control-helper class="normalized-vendors-help"><strong>Example:</strong> "Target" instead of "Target #0973226"</clr-control-helper>
+        </clr-checkbox-container>
+      </div>
+
+      <div *ngIf="settingsModel.syncReimbursements">
+        <h5>Reimbursements</h5>
+        <clr-radio-container>
+          <clr-radio-wrapper>
+            <input type="radio" clrRadio required name="syncReimbursementsCreateContact" [value]="false" [(ngModel)]="settingsModel.syncReimbursementsCreateContact" />
+            <label>
+              <span>Use a single contact </span>
+              <div *ngIf="!settingsModel.syncReimbursementsCreateContact" class="clr-select-wrapper">
+                <select id="select-reimbursements-contact"
+                        class="clr-select"
+                        name="reimbursementsAplosContactId"
+                        [(ngModel)]="settingsModel.reimbursementsAplosContactId">
+                  <option></option>
+                  <option [value]="contact.id" *ngFor="let contact of aplosContacts">{{contact.name}}</option>
+                </select>
+              </div>
+            </label>
+          </clr-radio-wrapper>
+          <clr-radio-wrapper>
+            <input type="radio" clrRadio required name="syncReimbursementsCreateContact" [value]="true" [(ngModel)]="settingsModel.syncReimbursementsCreateContact" />
+            <label>Create a contact for each employee</label>
+          </clr-radio-wrapper>
+        </clr-radio-container>
+      </div>
     </form>
 
     <clr-spinner *ngIf="savingSettings">
@@ -400,7 +431,7 @@
                    || !expenseAccountForm.valid
                    || (this.aplosTagCategories.length > 0 && !tagMappingForm.valid)">
 
-    <ng-template clrPageNavTitle>Purchases and Reimbursements</ng-template>
+    <ng-template clrPageNavTitle>{{ tagMappingPageTitle }}</ng-template>
     <ng-template clrPageTitle>Configure tag mapping options</ng-template>
 
     <clr-spinner *ngIf="savingSettings">
@@ -412,7 +443,7 @@
       <ul class="circle-list">
         <li><p class="display-inline">Map each Aplos field to a PEX tag. Only dropdown tags can be mapped.</p></li>
         <li><p class="display-inline">Enable the sync toggle for fields you want to sync as tag values.</p></li>
-        <li><p class="display-inline">Optionally, set a default value — applied to purchases and reimbursements when a transaction isn't tagged before syncing.</p></li>
+        <li><p class="display-inline">Optionally, set a default value — applied to {{ tagMappingPageTitle.toLowerCase() }} when a transaction isn't tagged before syncing.</p></li>
       </ul>
 
       <table class="table table-5col">
@@ -616,10 +647,7 @@
       (clrWizardPageOnLoad)="updateOtherOptionsValidators()"
       (clrWizardPageOnCommit)="onDefaultCategoryCommit()"
       (clrWizardPageOnCancel)="onCloseWizard()"
-      [clrWizardPageNextDisabled]="!defaultCategoryForm.valid
-        || (settingsModel.syncReimbursements
-            && !defaultCategoryForm.get('syncReimbursementsCreateContact').value
-            && !(defaultCategoryForm.get('reimbursementsAplosContactId').value > 0))">
+      [clrWizardPageNextDisabled]="!defaultCategoryForm.valid">
 
     <ng-template clrPageNavTitle>Other Options</ng-template>
     <ng-template  clrPageTitle>
@@ -641,9 +669,9 @@
 
     <form clrForm [formGroup]="defaultCategoryForm" [class.hide]="!savingSettings">
 
-      <!-- Purchases -->
-      <table class="table table-2col" *ngIf="!hasTagsAvailable  && settingsModel.syncTransactions">
-        <caption>Purchases</caption>
+      <!-- Purchases / Reimbursements shared defaults (no-tags businesses only) -->
+      <table class="table table-2col" *ngIf="!hasTagsAvailable && (settingsModel.syncTransactions || settingsModel.syncReimbursements)">
+        <caption>{{ tagMappingPageTitle }}</caption>
         <thead>
           <tr>
             <th class="left">Field</th>
@@ -1015,82 +1043,12 @@
           </thead>
           <tbody>
             <tr>
-              <td class="left contact-mapping-cell" colspan="2">
-                <div class="contact-mapping-box">
-                  <h5 class="contact-mapping-label">Contact mapping</h5>
-                  <clr-radio-container>
-                    <clr-radio-wrapper>
-                      <input type="radio" clrRadio [value]="false" formControlName="syncReimbursementsCreateContact" />
-                      <label>
-                        Use a single contact
-                        <span *ngIf="!defaultCategoryForm.get('syncReimbursementsCreateContact')?.value" class="inline-select">
-                          <div class="clr-select-wrapper">
-                            <select class="clr-select select" formControlName="reimbursementsAplosContactId" aria-label="Contact for reimbursements">
-                              <option></option>
-                              <option [value]="aplosContact.id" *ngFor="let aplosContact of aplosContacts">{{aplosContact.name}}</option>
-                            </select>
-                          </div>
-                        </span>
-                      </label>
-                    </clr-radio-wrapper>
-                    <clr-radio-wrapper>
-                      <input type="radio" clrRadio [value]="true" formControlName="syncReimbursementsCreateContact" />
-                      <label>Create a contact for each employee</label>
-                    </clr-radio-wrapper>
-                  </clr-radio-container>
-                </div>
-              </td>
-            </tr>
-            <tr>
-              <td class="left">Fund</td>
+              <td class="left">Bank Account</td>
               <td class="left">
                 <div class="clr-select-wrapper">
-                  <select class="clr-select select" required formControlName="reimbursementsAplosFundId" aria-label="Fund for reimbursements">
+                  <select class="clr-select select" required formControlName="reimbursementsAplosRegisterAccountNumber" aria-label="Bank account for reimbursements">
                     <option></option>
-                    <option [value]="aplosFund.id" *ngFor="let aplosFund of aplosFunds">{{aplosFund.name}}</option>
-                  </select>
-                </div>
-              </td>
-            </tr>
-            <tr>
-              <td class="left">Account</td>
-              <td class="left">
-                <div class="clr-select-wrapper">
-                  <select class="clr-select select" required formControlName="reimbursementsAplosTransactionAccountNumber" aria-label="Account for reimbursements">
-                    <option></option>
-                    <option [value]="aplosAccount.id" *ngFor="let aplosAccount of aplosExpenseAccounts">{{aplosAccount | aplosAccount}}</option>
-                  </select>
-                </div>
-              </td>
-            </tr>
-            <tr *ngIf="settingsModel.syncTaxTagToPex">
-              <td class="left">990 Tag Option</td>
-              <td class="left">
-                <div class="clr-select-wrapper">
-                  <select class="clr-select select clr-col-12" required formControlName="reimbursementsAplosTaxTag" aria-label="990 tag for reimbursements">
-                    <option></option>
-                    <optgroup *ngFor="let aplosTaxTagCategory of aplosTaxTagCategories" label="{{aplosTaxTagCategory.name}}">
-                      <option [value]="aplosTaxTag.id" *ngFor="let aplosTaxTag of aplosTaxTagCategory.tax_tags">{{aplosTaxTag.name}} - {{aplosTaxTag.group_name}}</option>
-                    </optgroup>
-                  </select>
-                </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-
-        <table class="table table-2col table-no-top-margin">
-          <caption class="caption-border">Reimbursement tags default values</caption>
-          <tbody formArrayName="reimbursementTagMappings">
-            <tr *ngFor="let tagMapping of getReimbursementTagMappingFormElements().controls; let i = index" [formGroupName]="i">
-              <td class="left">{{tagMapping.get('aplosTagCategoryName')?.value}}</td>
-              <td class="left">
-                <div class="clr-select-wrapper">
-                  <select class="clr-select" formControlName="defaultAplosTagValue">
-                    <option value=""></option>
-                    <option [value]="tagValue.id" *ngFor="let tagValue of getTagValuesForCategory(tagMapping.get('aplosTagCategoryId')?.value)">
-                      {{tagValue.name}}
-                    </option>
+                    <option [value]="aplosAccount.id" *ngFor="let aplosAccount of aplosAssetAccounts">{{aplosAccount | aplosAccount}}</option>
                   </select>
                 </div>
               </td>

--- a/src/AplosConnector.Web/ClientApp/src/app/sync-connect/sync-connect.component.ts
+++ b/src/AplosConnector.Web/ClientApp/src/app/sync-connect/sync-connect.component.ts
@@ -70,12 +70,6 @@ export class SyncConnectComponent implements OnInit {
         defaultAplosTagValue: new UntypedFormControl()
       })
     ]),
-    reimbursementTagMappings: new UntypedFormArray([
-      new UntypedFormGroup({
-        aplosTagId: new UntypedFormControl(),
-        defaultAplosTagValue: new UntypedFormControl()
-      })
-    ]),
     defaultAplosFundId: new UntypedFormControl(),
     defaultAplosTransactionAccountNumber: new UntypedFormControl(),
     transfersAplosContactId: new UntypedFormControl(),
@@ -89,11 +83,7 @@ export class SyncConnectComponent implements OnInit {
     pexRebatesAplosFundId: new UntypedFormControl(),
     pexRebatesAplosTransactionAccountNumber: new UntypedFormControl(),
     pexRebatesAplosTaxTag: new UntypedFormControl(),
-    syncReimbursementsCreateContact: new UntypedFormControl(),
-    reimbursementsAplosContactId: new UntypedFormControl(),
-    reimbursementsAplosFundId: new UntypedFormControl(),
-    reimbursementsAplosTransactionAccountNumber: new UntypedFormControl(),
-    reimbursementsAplosTaxTag: new UntypedFormControl()
+    reimbursementsAplosRegisterAccountNumber: new UntypedFormControl()
   });
 
 
@@ -188,9 +178,7 @@ export class SyncConnectComponent implements OnInit {
     pexRebatesAplosTaxTag: '',
     syncReimbursementsCreateContact: true, // default new mappings to "Create a contact for each employee"
     reimbursementsAplosContactId: 0,
-    reimbursementsAplosFundId: 0,
-    reimbursementsAplosTransactionAccountNumber: 0,
-    reimbursementsAplosTaxTag: '',
+    reimbursementsAplosRegisterAccountNumber: 0,
     expenseAccountMappings: [],
     tagMappings: [],
     taxTagCategoryDetails: [],
@@ -201,7 +189,6 @@ export class SyncConnectComponent implements OnInit {
     transferTagMappings: [],
     feeTagMappings: [],
     rebateTagMappings: [],
-    reimbursementTagMappings: [],
     syncInvoicesMethod: SyncInvoicesMethod.RebateDistribute
   };
 
@@ -247,6 +234,16 @@ export class SyncConnectComponent implements OnInit {
         tagMappingRowValidator
       )
     );
+  }
+
+  // Single shared mapping step: the title reflects which syncs are enabled.
+  get tagMappingPageTitle(): string {
+    const purchases = this.settingsModel.syncTransactions;
+    const reimbursements = this.settingsModel.syncReimbursements;
+    if (purchases && reimbursements) {
+      return 'Purchases and Reimbursements';
+    }
+    return reimbursements ? 'Reimbursements' : 'Purchases';
   }
 
   get earliestTransactionDateToSync() {
@@ -506,7 +503,6 @@ export class SyncConnectComponent implements OnInit {
       this.initializeTransferTagMappings();
       this.initializeFeeTagMappings();
       this.initializeRebateTagMappings();
-      this.initializeReimbursementTagMappings();
     }
   }
 
@@ -546,7 +542,6 @@ export class SyncConnectComponent implements OnInit {
         this.initializeTransferTagMappings();
         this.initializeFeeTagMappings();
         this.initializeRebateTagMappings();
-        this.initializeReimbursementTagMappings();
       },
       () => {
         this.loadingAplosTaxTags = false;
@@ -614,12 +609,11 @@ export class SyncConnectComponent implements OnInit {
       this.initExpenseAccountMappingFormFromSettings(this.settingsModel);
       this.initTagMappingFormFromSettings(this.settingsModel);
       this.initDefaultCategoryFormFromSettings(this.settingsModel);
-      
+
       // Initialize tag mappings from settings
       this.initializeTransferTagMappings();
       this.initializeFeeTagMappings();
       this.initializeRebateTagMappings();
-      this.initializeReimbursementTagMappings();
 
       if (this.settingsModel.tagMappings.length > 0) {
         this.settingsModel.tagMappings.forEach(
@@ -682,21 +676,20 @@ export class SyncConnectComponent implements OnInit {
       pexRebatesAplosFundId: settings.pexRebatesAplosFundId,
       pexRebatesAplosTransactionAccountNumber: settings.pexRebatesAplosTransactionAccountNumber,
       pexRebatesAplosTaxTag: settings.pexRebatesAplosTaxTag,
-      syncReimbursementsCreateContact: settings.syncReimbursementsCreateContact,
-      reimbursementsAplosContactId: settings.reimbursementsAplosContactId,
-      reimbursementsAplosFundId: settings.reimbursementsAplosFundId,
-      reimbursementsAplosTransactionAccountNumber: settings.reimbursementsAplosTransactionAccountNumber,
-      reimbursementsAplosTaxTag: settings.reimbursementsAplosTaxTag
+      reimbursementsAplosRegisterAccountNumber: settings.reimbursementsAplosRegisterAccountNumber
     });
 
     this.updateOtherOptionsValidators();
   }
 
-  private applyRequired(controlName: string, isRequired: boolean) {
+  // Numeric id selects are patched with the server's 0, which Validators.required
+  // treats as a present value — min(1) is what actually forces a selection. String
+  // controls (tax tags) keep plain required.
+  private applyRequired(controlName: string, isRequired: boolean, isNumericId = true) {
     const control = this.defaultCategoryForm.get(controlName);
     if (!control) { return; }
     if (isRequired) {
-      control.setValidators(Validators.required);
+      control.setValidators(isNumericId ? [Validators.required, Validators.min(1)] : Validators.required);
     } else {
       control.clearValidators();
     }
@@ -720,8 +713,8 @@ export class SyncConnectComponent implements OnInit {
     const transfersOrInvoices = s.syncTransfers || s.syncInvoices;
     const rebatesVisible = (s.syncTransactions && s.syncRebates) || s.syncInvoices;
 
-    // Purchases (only shown when tags unavailable)
-    const purchasesVisible = !this.hasTagsAvailable && s.syncTransactions;
+    // Shared purchases/reimbursements defaults (only shown when tags unavailable)
+    const purchasesVisible = !this.hasTagsAvailable && (s.syncTransactions || s.syncReimbursements);
     this.applyRequired('defaultAplosFundId', purchasesVisible);
     this.applyRequired('defaultAplosTransactionAccountNumber', purchasesVisible);
 
@@ -734,18 +727,17 @@ export class SyncConnectComponent implements OnInit {
     this.applyRequired('pexFeesAplosContactId', s.syncPexFees);
     this.applyRequired('pexFeesAplosFundId', s.syncPexFees);
     this.applyRequired('pexFeesAplosTransactionAccountNumber', s.syncPexFees);
-    this.applyRequired('pexFeesAplosTaxTag', s.syncPexFees && s.syncTaxTagToPex);
+    this.applyRequired('pexFeesAplosTaxTag', s.syncPexFees && s.syncTaxTagToPex, false);
 
     // Rebates
     this.applyRequired('pexRebatesAplosContactId', rebatesVisible && this.isPrepaid);
     this.applyRequired('pexRebatesAplosFundId', rebatesVisible && (this.isPrepaid || (this.isCredit && this.invoiceMethodRequiresRebateFund)));
     this.applyRequired('pexRebatesAplosTransactionAccountNumber', rebatesVisible);
-    this.applyRequired('pexRebatesAplosTaxTag', rebatesVisible && s.syncTaxTagToPex);
+    this.applyRequired('pexRebatesAplosTaxTag', rebatesVisible && s.syncTaxTagToPex, false);
 
-    // Reimbursements
-    this.applyRequired('reimbursementsAplosFundId', s.syncReimbursements);
-    this.applyRequired('reimbursementsAplosTransactionAccountNumber', s.syncReimbursements);
-    this.applyRequired('reimbursementsAplosTaxTag', s.syncReimbursements && s.syncTaxTagToPex);
+    // Reimbursements: only the bank account (register line) is configured here —
+    // fund/expense/tags come from the shared mapping page or the shared defaults above.
+    this.applyRequired('reimbursementsAplosRegisterAccountNumber', s.syncReimbursements);
   }
 
   updateSettingsFromDefaultCategoryForm() {
@@ -753,8 +745,8 @@ export class SyncConnectComponent implements OnInit {
     const formValue = this.defaultCategoryForm.value;
     
     // Only update defaultAplosFundId if it's being used in the transaction options form
-    // (when tags are not available and sync transactions is enabled)
-    if (!this.hasTagsAvailable && this.settingsModel.syncTransactions) {
+    // (when tags are not available and purchases or reimbursements sync is enabled)
+    if (!this.hasTagsAvailable && (this.settingsModel.syncTransactions || this.settingsModel.syncReimbursements)) {
       this.settingsModel.defaultAplosFundId = formValue.defaultAplosFundId;
       this.settingsModel.defaultAplosTransactionAccountNumber = formValue.defaultAplosTransactionAccountNumber;
     }
@@ -770,11 +762,7 @@ export class SyncConnectComponent implements OnInit {
     this.settingsModel.pexRebatesAplosFundId = formValue.pexRebatesAplosFundId;
     this.settingsModel.pexRebatesAplosTransactionAccountNumber = formValue.pexRebatesAplosTransactionAccountNumber;
     this.settingsModel.pexRebatesAplosTaxTag = formValue.pexRebatesAplosTaxTag;
-    this.settingsModel.syncReimbursementsCreateContact = formValue.syncReimbursementsCreateContact;
-    this.settingsModel.reimbursementsAplosContactId = formValue.reimbursementsAplosContactId;
-    this.settingsModel.reimbursementsAplosFundId = formValue.reimbursementsAplosFundId;
-    this.settingsModel.reimbursementsAplosTransactionAccountNumber = formValue.reimbursementsAplosTransactionAccountNumber;
-    this.settingsModel.reimbursementsAplosTaxTag = formValue.reimbursementsAplosTaxTag;
+    this.settingsModel.reimbursementsAplosRegisterAccountNumber = formValue.reimbursementsAplosRegisterAccountNumber;
   }
 
   private validatePexSetup() {
@@ -861,7 +849,6 @@ export class SyncConnectComponent implements OnInit {
   onSyncTransactionChange() {
     if (!this.settingsModel.syncTransactions) {
       this.settingsModel.syncRebates = false;
-      this.settingsModel.syncReimbursements = false;
       if (this.isCredit) {
         this.settingsModel.syncInvoices = false;
       }
@@ -1032,52 +1019,6 @@ export class SyncConnectComponent implements OnInit {
     console.log('Updated feeTagMappings:', this.settingsModel.feeTagMappings);
   }
 
-  getReimbursementTagMappingFormElements() {
-    return this.defaultCategoryForm.get('reimbursementTagMappings') as FormArray;
-  }
-
-  initializeReimbursementTagMappings() {
-    const reimbursementTagMappingsArray = this.defaultCategoryForm.get('reimbursementTagMappings') as FormArray;
-
-    // Clear existing form controls
-    while (reimbursementTagMappingsArray.length !== 0) {
-      reimbursementTagMappingsArray.removeAt(0);
-    }
-
-    // Add a form group for each aplos tag category
-    this.aplosTagCategories.forEach(category => {
-      // Find existing setting for this category
-      const existingMapping = this.settingsModel.reimbursementTagMappings?.find(
-        mapping => mapping.aplosTagId === category.id.toString()
-      );
-
-      const formGroup = new UntypedFormGroup({
-        aplosTagCategoryId: new UntypedFormControl(category.id.toString()),
-        aplosTagCategoryName: new UntypedFormControl(category.name),
-        defaultAplosTagValue: new UntypedFormControl(existingMapping?.defaultAplosTagValue || '')
-      });
-      reimbursementTagMappingsArray.push(formGroup);
-    });
-  }
-
-  updateSettingsFromReimbursementTagMappingsForm() {
-    const formArray = this.getReimbursementTagMappingFormElements();
-    this.settingsModel.reimbursementTagMappings = [];
-
-    formArray.controls.forEach(control => {
-      const categoryId = control.get('aplosTagCategoryId')?.value;
-      const selectedValue = control.get('defaultAplosTagValue')?.value;
-
-      if (categoryId && selectedValue) {
-        this.settingsModel.reimbursementTagMappings.push({
-          aplosTagId: categoryId,
-          defaultAplosTagValue: selectedValue
-        });
-      }
-    });
-    console.log('Updated reimbursementTagMappings:', this.settingsModel.reimbursementTagMappings);
-  }
-
   updateSettingsFromRebateTagMappingsForm() {
     const formArray = this.getRebateTagMappingFormElements();
     this.settingsModel.rebateTagMappings = [];
@@ -1157,6 +1098,9 @@ export class SyncConnectComponent implements OnInit {
     } else {
       this.settingsModel.useNormalizedMerchantNames = false;
     }
+    if (this.settingsModel.syncReimbursementsCreateContact) {
+      this.settingsModel.reimbursementsAplosContactId = 0;
+    }
     console.log('saving contact options settings', this.settingsModel);
     return this.mapping.saveSettings(this.sessionId, this.settingsModel);
   }
@@ -1177,7 +1121,6 @@ export class SyncConnectComponent implements OnInit {
     this.updateSettingsFromTransferTagMappingsForm();
     this.updateSettingsFromFeeTagMappingsForm();
     this.updateSettingsFromRebateTagMappingsForm();
-    this.updateSettingsFromReimbursementTagMappingsForm();
     console.log('saving transaction options settings', this.settingsModel);
     return this.mapping.saveSettings(this.sessionId, this.settingsModel);
   }

--- a/src/AplosConnector.Web/ClientApp/src/app/sync-manage/sync-manage.component.html
+++ b/src/AplosConnector.Web/ClientApp/src/app/sync-manage/sync-manage.component.html
@@ -238,17 +238,9 @@
                 <span *ngIf="!settings.syncReimbursementsCreateContact && reimbursementsContact">{{reimbursementsContact.name}}</span>
               </td>
             </tr>
-            <tr class="left" *ngIf="settings.syncReimbursements && reimbursementsFund">
-              <th>Fund for reimbursements</th>
-              <td>{{reimbursementsFund.name}}</td>
-            </tr>
-            <tr class="left" *ngIf="settings.syncReimbursements && reimbursementsAccount">
-              <th>Transaction account for reimbursements</th>
-              <td>{{reimbursementsAccount | aplosAccount}}</td>
-            </tr>
-            <tr class="left" *ngIf="settings.syncTaxTagToPex && settings.reimbursementsAplosTaxTag">
-              <th>990 tag for reimbursements</th>
-              <td>{{reimbursementsAplosTaxTagName}}</td>
+            <tr class="left" *ngIf="settings.syncReimbursements && reimbursementsBankAccount">
+              <th>Bank account for reimbursements</th>
+              <td>{{reimbursementsBankAccount | aplosAccount}}</td>
             </tr>
           </tbody>
         </table>

--- a/src/AplosConnector.Web/ClientApp/src/app/sync-manage/sync-manage.component.ts
+++ b/src/AplosConnector.Web/ClientApp/src/app/sync-manage/sync-manage.component.ts
@@ -34,7 +34,6 @@ export class SyncManageComponent implements OnInit {
   transfersAplosTaxTagName: string = ''
   pexFeesAplosTaxTagName: string = ''
   pexRebatesAplosTaxTagName: string = ''
-  reimbursementsAplosTaxTagName: string = ''
 
   defaultContact: AplosObject;
   defaultFund: AplosObject;
@@ -54,8 +53,7 @@ export class SyncManageComponent implements OnInit {
   rebatesAccount: AplosObject;
 
   reimbursementsContact: AplosObject;
-  reimbursementsFund: AplosObject;
-  reimbursementsAccount: AplosObject;
+  reimbursementsBankAccount: AplosObject;
 
   AplosPreferences: AplosPreferences = { isClassEnabled: false, isLocationEnabled: false, locationFieldName: '' };
   isPrepaid: boolean = false;
@@ -201,9 +199,6 @@ export class SyncManageComponent implements OnInit {
     if (this.settings.pexRebatesAplosTaxTag) {
       this.pexRebatesAplosTaxTagName = this.getTaxTagName(this.settings.pexRebatesAplosTaxTag.toString());
     }
-    if (this.settings.reimbursementsAplosTaxTag) {
-      this.reimbursementsAplosTaxTagName = this.getTaxTagName(this.settings.reimbursementsAplosTaxTag.toString());
-    }
   }
 
   getTaxTagName(taxTagId: string) {
@@ -293,7 +288,7 @@ export class SyncManageComponent implements OnInit {
 
   getReimbursementsInfo() {
     if (this.settings.syncReimbursements) {
-      if (!this.settings.syncReimbursementsCreateContact) {
+      if (!this.settings.syncReimbursementsCreateContact && this.settings.reimbursementsAplosContactId > 0) {
         this.aplos.getContact(this.sessionId, this.settings.reimbursementsAplosContactId).subscribe(
           contact => {
             console.log('got reimbursements contact', contact);
@@ -302,19 +297,14 @@ export class SyncManageComponent implements OnInit {
         );
       }
 
-      this.aplos.getFund(this.sessionId, this.settings.reimbursementsAplosFundId).subscribe(
-        fund => {
-          console.log('got reimbursements fund', fund);
-          this.reimbursementsFund = { ...fund };
-        }
-      );
-
-      this.aplos.getAccount(this.sessionId, this.settings.reimbursementsAplosTransactionAccountNumber).subscribe(
-        account => {
-          console.log('got reimbursements account', account);
-          this.reimbursementsAccount = { ...account };
-        }
-      );
+      if (this.settings.reimbursementsAplosRegisterAccountNumber > 0) {
+        this.aplos.getAccount(this.sessionId, this.settings.reimbursementsAplosRegisterAccountNumber).subscribe(
+          account => {
+            console.log('got reimbursements bank account', account);
+            this.reimbursementsBankAccount = { ...account };
+          }
+        );
+      }
     }
   }
 

--- a/tests/AplosConnector.Common.Tests/AplosIntegrationServiceTests.cs
+++ b/tests/AplosConnector.Common.Tests/AplosIntegrationServiceTests.cs
@@ -753,22 +753,25 @@ namespace AplosConnector.Common.Tests
         [InlineData(0, 1, 1, "Contact not configured")]
         [InlineData(1, 0, 1, "Fund not configured")]
         [InlineData(1, 1, 0, "Account not configured")]
-        public void Pex2AplosMappingModel_SyncReimbursements_RequiresAllDefaults(
+        public void Pex2AplosMappingModel_SyncReimbursements_RequiresSharedConfig(
             int contactId, int fundId, decimal accountNumber, string scenario)
         {
-            //Arrange — verify the mapping model can hold reimbursement config
+            //Arrange — reimbursements use the shared purchases mapping config plus their own contact
             var mapping = new Pex2AplosMappingModel
             {
                 SyncReimbursements = true,
                 ReimbursementsAplosContactId = contactId,
-                ReimbursementsAplosFundId = fundId,
-                ReimbursementsAplosTransactionAccountNumber = accountNumber,
+                DefaultAplosFundId = fundId,
+                DefaultAplosTransactionAccountNumber = accountNumber,
             };
 
-            //Act
+            //Act — mirrors the guard check in SyncReimbursements (defaults-only configuration)
+            bool hasFundConfig = mapping.DefaultAplosFundId > 0 || !string.IsNullOrEmpty(mapping.PexFundsTagId);
+            bool hasAccountConfig = mapping.DefaultAplosTransactionAccountNumber > 0;
             bool isConfigured = mapping.ReimbursementsAplosContactId > 0
-                && mapping.ReimbursementsAplosFundId > 0
-                && mapping.ReimbursementsAplosTransactionAccountNumber > 0;
+                && mapping.ReimbursementsAplosRegisterAccountNumber > 0
+                && hasFundConfig
+                && hasAccountConfig;
 
             //Assert
             Assert.False(isConfigured, $"Should not be fully configured when: {scenario}");
@@ -793,10 +796,7 @@ namespace AplosConnector.Common.Tests
                 SyncReimbursements = true,
                 SyncReimbursementsCreateContact = true,
                 ReimbursementsAplosContactId = 42,
-                ReimbursementsAplosFundId = 7,
-                ReimbursementsAplosTransactionAccountNumber = 5010,
-                ReimbursementsAplosTaxTagId = "990-1",
-                ReimbursementTagMappings = new[] { new AplosTagMappingModel { AplosTagId = "cat1", DefaultAplosTagValue = "val1" } },
+                ReimbursementsAplosRegisterAccountNumber = 1200,
             };
 
             //Act
@@ -806,12 +806,7 @@ namespace AplosConnector.Common.Tests
             Assert.True(storageModel.SyncReimbursements);
             Assert.True(storageModel.SyncReimbursementsCreateContact);
             Assert.Equal(42, storageModel.ReimbursementsAplosContactId);
-            Assert.Equal(7, storageModel.ReimbursementsAplosFundId);
-            Assert.Equal(5010, storageModel.ReimbursementsAplosTransactionAccountNumber);
-            Assert.Equal("990-1", storageModel.ReimbursementsAplosTaxTag);
-            Assert.NotNull(storageModel.ReimbursementTagMappings);
-            Assert.Single(storageModel.ReimbursementTagMappings);
-            Assert.Equal("cat1", storageModel.ReimbursementTagMappings[0].AplosTagId);
+            Assert.Equal(1200, storageModel.ReimbursementsAplosRegisterAccountNumber);
         }
 
         [Fact]
@@ -822,10 +817,7 @@ namespace AplosConnector.Common.Tests
             var settings = mapping.ToStorageModel();
             settings.SyncReimbursements = true;
             settings.ReimbursementsAplosContactId = 10;
-            settings.ReimbursementsAplosFundId = 20;
-            settings.ReimbursementsAplosTransactionAccountNumber = 3000;
-            settings.ReimbursementsAplosTaxTag = "990-2";
-            settings.ReimbursementTagMappings = new[] { new AplosTagMappingModel { AplosTagId = "c2", DefaultAplosTagValue = "v2" } };
+            settings.ReimbursementsAplosRegisterAccountNumber = 1300;
 
             //Act
             mapping.UpdateFromSettings(settings);
@@ -833,10 +825,7 @@ namespace AplosConnector.Common.Tests
             //Assert
             Assert.True(mapping.SyncReimbursements);
             Assert.Equal(10, mapping.ReimbursementsAplosContactId);
-            Assert.Equal(20, mapping.ReimbursementsAplosFundId);
-            Assert.Equal(3000, mapping.ReimbursementsAplosTransactionAccountNumber);
-            Assert.Equal("990-2", mapping.ReimbursementsAplosTaxTagId);
-            Assert.Single(mapping.ReimbursementTagMappings);
+            Assert.Equal(1300, mapping.ReimbursementsAplosRegisterAccountNumber);
         }
 
         [Fact]
@@ -854,8 +843,6 @@ namespace AplosConnector.Common.Tests
             {
                 SyncReimbursementsCreateContact = true,
                 ReimbursementsAplosContactId = 42,
-                ReimbursementsAplosFundId = 7,
-                ReimbursementsAplosTransactionAccountNumber = 5010,
             };
 
             //Act
@@ -889,14 +876,16 @@ namespace AplosConnector.Common.Tests
                 SyncReimbursements = true,
                 SyncReimbursementsCreateContact = true,
                 ReimbursementsAplosContactId = 0,
-                ReimbursementsAplosFundId = 200,
-                ReimbursementsAplosTransactionAccountNumber = 5000,
+                ReimbursementsAplosRegisterAccountNumber = 1200,
+                DefaultAplosFundId = 200,
+                DefaultAplosTransactionAccountNumber = 5000,
             };
 
             //Act — mirrors the guard check in SyncReimbursements
             bool isConfigured = (mapping.SyncReimbursementsCreateContact || mapping.ReimbursementsAplosContactId > 0)
-                && mapping.ReimbursementsAplosFundId > 0
-                && mapping.ReimbursementsAplosTransactionAccountNumber > 0;
+                && mapping.ReimbursementsAplosRegisterAccountNumber > 0
+                && (mapping.DefaultAplosFundId > 0 || !string.IsNullOrEmpty(mapping.PexFundsTagId))
+                && mapping.DefaultAplosTransactionAccountNumber > 0;
 
             //Assert
             Assert.True(isConfigured, "Should be configured when SyncReimbursementsCreateContact is true even without a contact ID");

--- a/tests/AplosConnector.Common.Tests/ReimbursementsRoundTripTests.cs
+++ b/tests/AplosConnector.Common.Tests/ReimbursementsRoundTripTests.cs
@@ -16,14 +16,7 @@ namespace AplosConnector.Common.Tests
             SyncReimbursements = true,
             SyncReimbursementsCreateContact = true,
             ReimbursementsAplosContactId = 777,
-            ReimbursementsAplosFundId = 888,
-            ReimbursementsAplosTransactionAccountNumber = 6100.25m,
-            ReimbursementsAplosTaxTagId = "tax-tag-7",
-            ReimbursementTagMappings = new[]
-            {
-                new AplosTagMappingModel { AplosTagId = "tag-1", DefaultAplosTagValue = "value-1" },
-                new AplosTagMappingModel { AplosTagId = "tag-2", DefaultAplosTagValue = "value-2" }
-            }
+            ReimbursementsAplosRegisterAccountNumber = 1000.50m
         };
 
         [Fact]
@@ -38,25 +31,7 @@ namespace AplosConnector.Common.Tests
             Assert.True(roundTripped.SyncReimbursements);
             Assert.True(roundTripped.SyncReimbursementsCreateContact);
             Assert.Equal(777, roundTripped.ReimbursementsAplosContactId);
-            Assert.Equal(888, roundTripped.ReimbursementsAplosFundId);
-            Assert.Equal(6100.25m, roundTripped.ReimbursementsAplosTransactionAccountNumber);
-            Assert.Equal("tax-tag-7", roundTripped.ReimbursementsAplosTaxTagId);
-        }
-
-        [Fact]
-        public void EntityRoundTrip_PreservesReimbursementTagMappings()
-        {
-            var service = NewService();
-            var original = BuildModelWithReimbursements();
-
-            var entity = service.Map(original);
-            var roundTripped = service.Map(entity);
-
-            Assert.NotNull(roundTripped.ReimbursementTagMappings);
-            Assert.Equal(2, roundTripped.ReimbursementTagMappings.Length);
-            Assert.Equal("tag-1", roundTripped.ReimbursementTagMappings[0].AplosTagId);
-            Assert.Equal("value-1", roundTripped.ReimbursementTagMappings[0].DefaultAplosTagValue);
-            Assert.Equal("tag-2", roundTripped.ReimbursementTagMappings[1].AplosTagId);
+            Assert.Equal(1000.50m, roundTripped.ReimbursementsAplosRegisterAccountNumber);
         }
 
         [Fact]
@@ -71,9 +46,7 @@ namespace AplosConnector.Common.Tests
             Assert.False(roundTripped.SyncReimbursements);
             Assert.False(roundTripped.SyncReimbursementsCreateContact);
             Assert.Equal(0, roundTripped.ReimbursementsAplosContactId);
-            Assert.Equal(0, roundTripped.ReimbursementsAplosFundId);
-            Assert.Equal(0m, roundTripped.ReimbursementsAplosTransactionAccountNumber);
-            Assert.Null(roundTripped.ReimbursementsAplosTaxTagId);
+            Assert.Equal(0m, roundTripped.ReimbursementsAplosRegisterAccountNumber);
         }
 
         [Fact]
@@ -88,58 +61,7 @@ namespace AplosConnector.Common.Tests
             Assert.True(rebuilt.SyncReimbursements);
             Assert.True(rebuilt.SyncReimbursementsCreateContact);
             Assert.Equal(777, rebuilt.ReimbursementsAplosContactId);
-            Assert.Equal(888, rebuilt.ReimbursementsAplosFundId);
-            Assert.Equal(6100.25m, rebuilt.ReimbursementsAplosTransactionAccountNumber);
-            Assert.Equal("tax-tag-7", rebuilt.ReimbursementsAplosTaxTagId);
-            Assert.NotNull(rebuilt.ReimbursementTagMappings);
-            Assert.Equal(2, rebuilt.ReimbursementTagMappings.Length);
-        }
-
-        [Fact]
-        public void SettingsModel_TaxTagPropertyDropsIdSuffix()
-        {
-            // MappingSettingsModel uses *TaxTag (no Id suffix), domain model uses *TaxTagId.
-            // Guards against accidental rename drift between the two models.
-            var original = BuildModelWithReimbursements();
-
-            var settings = original.ToStorageModel();
-
-            Assert.Equal("tax-tag-7", settings.ReimbursementsAplosTaxTag);
-        }
-
-        [Fact]
-        public void EntityRoundTrip_NullTagMappings_RemainsNull()
-        {
-            var service = NewService();
-            var original = new Pex2AplosMappingModel
-            {
-                PEXBusinessAcctId = 1,
-                SyncReimbursements = true,
-                ReimbursementTagMappings = null
-            };
-
-            var entity = service.Map(original);
-            var roundTripped = service.Map(entity);
-
-            Assert.Null(roundTripped.ReimbursementTagMappings);
-        }
-
-        [Fact]
-        public void EntityRoundTrip_EmptyTagMappings_RoundTripsToEmptyArray()
-        {
-            var service = NewService();
-            var original = new Pex2AplosMappingModel
-            {
-                PEXBusinessAcctId = 1,
-                SyncReimbursements = true,
-                ReimbursementTagMappings = new AplosTagMappingModel[0]
-            };
-
-            var entity = service.Map(original);
-            var roundTripped = service.Map(entity);
-
-            Assert.NotNull(roundTripped.ReimbursementTagMappings);
-            Assert.Empty(roundTripped.ReimbursementTagMappings);
+            Assert.Equal(1000.50m, rebuilt.ReimbursementsAplosRegisterAccountNumber);
         }
     }
 }


### PR DESCRIPTION
## Summary

Implements all four steps of bug [143012 "Aplos Reimbursements"](https://pexcard.visualstudio.com/PPS/_workitems/edit/143012), incorporating the ticket author's follow-up decisions (shared mapping page, no standardized-names option for reimbursements).

- **Step 1 — Independent toggle:** the Reimbursements sync toggle is always visible and no longer hides behind or gets reset by the purchases toggle.
- **Step 2 — Contact Options:** reimbursement contact mapping moved to the Contact Options step as its own labeled section (single contact / contact per employee), validated per visible section; reimbursement syncs use it independently of the purchases contact settings.
- **Step 3 — Shared mapping step:** single "Purchases and Reimbursements" mapping page with an adaptive title ("Purchases" / "Reimbursements" / both). Reimbursement syncs now resolve fund, expense account, category tags, and 990 per request from the employee's PEX tag answers via the shared mappings, falling back to the shared defaults when untagged.
- **Step 4 — Bank Account:** the Reimbursements section on Other Options is reduced to a single required Bank Account field (asset accounts, same list as Transfers) used as the register/cash line; reimbursements no longer use or require the PEX register account.

## Also in this PR

- Removed the legacy reimbursement-specific config fields (`ReimbursementTagMappings`, `ReimbursementsAplosFundId`/`TransactionAccountNumber`/`TaxTagId`) end-to-end — they only ever held sandbox data, no backward compatibility needed. Existing sandbox configs must be re-saved through the wizard.
- Per-item guard in `SyncReimbursements`: requests whose fund or expense account cannot be resolved are counted as failures instead of posting lines with `Id = 0`.
- Other Options numeric selects now validate with `min(1)` — `Validators.required` alone passes on the server-patched `0`, which let users skip required fields page-wide.
- All 990 tax tag application is gated on `SyncTaxTagToPex` across transaction, rebate, fee, and reimbursement paths.
- Tags are only attached to Aplos transaction lines when at least one tag is set.
- Sync-manage summary shows the reimbursement bank account.

## Tests

- `AplosConnector.Common.Tests` 56/56, `AplosConnector.Web.Tests` 120/120, `Aplos.Api.Client.Tests` 21/21; Angular production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)