### PR TITLE
Aplos: gate Reimbursements toggle by CSP business-account setting

### DIFF
--- a/src/AplosConnector.Common/Models/MappingSettingsModel.cs
+++ b/src/AplosConnector.Common/Models/MappingSettingsModel.cs
@@ -58,6 +58,10 @@ namespace AplosConnector.Common.Models
         /// Whether to sync PEX reimbursements to Aplos.
         /// </summary>
         public bool SyncReimbursements { get; set; }
+        /// <summary>
+        /// Whether the PEX business account has the Reimbursements feature enabled on CSP. Read-only; ignored if sent by the client.
+        /// </summary>
+        public bool UseReimbursementsEnabled { get; set; }
 
         /// <summary>
         /// The AccountId for the register to use in Aplos. This is the account from which money will be taken from in the transaction created in Aplos.

--- a/src/AplosConnector.Common/Models/Pex2AplosMappingModel.cs
+++ b/src/AplosConnector.Common/Models/Pex2AplosMappingModel.cs
@@ -176,7 +176,9 @@ namespace AplosConnector.Common.Models
                 IsTokenExpired = IsTokenExpired,
 
                 SyncInvoicesMethod = SyncInvoicesMethod,
-                SyncInvoiceAggregated = SyncInvoiceAggregated
+                SyncInvoiceAggregated = SyncInvoiceAggregated,
+
+                UseReimbursementsEnabled = UseReimbursementsEnabled
             };
         }
 
@@ -197,6 +199,9 @@ namespace AplosConnector.Common.Models
         public bool SyncInvoices { get; set; }
         public bool SyncRebates { get; set; }
         public bool SyncReimbursements { get; set; }
+
+        // Live PEX business-account flag, refreshed on each read via RefreshBusinessSettings — never persisted.
+        public bool UseReimbursementsEnabled { get; set; }
         public bool SyncApprovedOnly { get; set; }
         public DateTime EarliestTransactionDateToSync { get; set; }
         public DateTime? EndDateUtc { get; set; }

--- a/src/AplosConnector.Common/Services/Abstractions/IAplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/Abstractions/IAplosIntegrationService.cs
@@ -31,7 +31,7 @@ namespace AplosConnector.Common.Services.Abstractions
         Task<TransactionSyncResult> SyncTransaction(IEnumerable<(AllocationTagValue allocation, PexTagValuesModel pexTagValues)> allocationDetails, Pex2AplosMappingModel mapping, TransactionModel transaction, CardholderDetailsModel cardholderDetails, List<VendorCardOrdered> vendorCardsOrdered, CancellationToken cancellationToken);
         Task<Pex2AplosMappingModel> EnsureMappingInstalled(PexOAuthSessionModel session, CancellationToken cancellationToken);
         Task<IEnumerable<AplosApiTaxTagCategoryDetail>> GetAplosApiTaxTagExpenseCategoryDetails(Pex2AplosMappingModel mapping, CancellationToken cancellationToken);
-        Task<Pex2AplosMappingModel> UpdateFundingSource(Pex2AplosMappingModel mapping, CancellationToken cancellationToken);
+        Task<Pex2AplosMappingModel> RefreshBusinessSettings(Pex2AplosMappingModel mapping, CancellationToken cancellationToken);
         Task<AplosApiPayablesListResponse> GetAplosPayables(Pex2AplosMappingModel mapping, DateTime startDate, CancellationToken cancellationToken);
     }
 }

--- a/src/AplosConnector.Common/Services/AplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/AplosIntegrationService.cs
@@ -747,7 +747,25 @@ namespace AplosConnector.Common.Services
 
         public async Task<Pex2AplosMappingModel> RefreshBusinessSettings(Pex2AplosMappingModel mapping, CancellationToken cancellationToken)
         {
-            var businessSettings = await _pexApiClient.GetBusinessSettings(mapping.PEXExternalAPIToken, cancellationToken);
+            BusinessSettingsModel businessSettings;
+            try
+            {
+                businessSettings = await _pexApiClient.GetBusinessSettings(mapping.PEXExternalAPIToken, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                if (mapping.PEXFundingSource == 0)
+                {
+                    // First-time load: there's no prior known state to fall back to, so surface the
+                    // failure rather than silently returning a wizard with everything unresolved.
+                    throw;
+                }
+
+                // Degrade gracefully: a PEX outage here shouldn't fail Settings load/save for
+                // businesses that don't strictly need fresh data (e.g. funding source already cached).
+                _logger.LogWarning(ex, $"Failed to refresh business settings for business {mapping.PEXBusinessAcctId}. Using last-known values.");
+                return mapping;
+            }
 
             if (mapping.PEXFundingSource == 0)
             {

--- a/src/AplosConnector.Common/Services/AplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/AplosIntegrationService.cs
@@ -745,12 +745,21 @@ namespace AplosConnector.Common.Services
             return taxTags.Where(c => c.Type == "expense");
         }
 
-        public async Task<Pex2AplosMappingModel> UpdateFundingSource(Pex2AplosMappingModel mapping, CancellationToken cancellationToken)
+        public async Task<Pex2AplosMappingModel> RefreshBusinessSettings(Pex2AplosMappingModel mapping, CancellationToken cancellationToken)
         {
+            var businessSettings = await _pexApiClient.GetBusinessSettings(mapping.PEXExternalAPIToken, cancellationToken);
+
             if (mapping.PEXFundingSource == 0)
             {
-                var businessSettings = await _pexApiClient.GetBusinessSettings(mapping.PEXExternalAPIToken, cancellationToken);
                 mapping.PEXFundingSource = businessSettings.FundingSource;
+            }
+
+            mapping.UseReimbursementsEnabled = businessSettings.UseReimbursements;
+
+            if (mapping.SyncReimbursements && !businessSettings.UseReimbursements)
+            {
+                mapping.SyncReimbursements = false;
+                await _mappingStorage.UpdateAsync(mapping, cancellationToken);
             }
 
             return mapping;
@@ -2542,6 +2551,13 @@ namespace AplosConnector.Common.Services
             CancellationToken cancellationToken)
         {
             if (!mapping.SyncReimbursements) return;
+
+            await RefreshBusinessSettings(mapping, cancellationToken);
+            if (!mapping.SyncReimbursements)
+            {
+                logger.LogInformation($"Skipping sync reimbursements for business {mapping.PEXBusinessAcctId}. Reimbursements are disabled for this business account.");
+                return;
+            }
 
             // Reimbursements share the purchases mapping configuration (the "Purchases and
             // Reimbursements" wizard page): fund, expense account, category tags, and 990

--- a/src/AplosConnector.Web/ClientApp/src/app/services/mapping.service.ts
+++ b/src/AplosConnector.Web/ClientApp/src/app/services/mapping.service.ts
@@ -110,6 +110,7 @@ export interface SettingsModel {
   syncPexFees: boolean;
   syncRebates: boolean;
   syncReimbursements: boolean;
+  useReimbursementsEnabled: boolean;
 
   transfersAplosContactId: number;
   transfersAplosFundId: number;

--- a/src/AplosConnector.Web/ClientApp/src/app/sync-connect/sync-connect.component.html
+++ b/src/AplosConnector.Web/ClientApp/src/app/sync-connect/sync-connect.component.html
@@ -246,7 +246,7 @@
         <label>Automatically import bill payments and rebates into Aplos.</label>
       </clr-toggle-wrapper>
 
-      <clr-toggle-wrapper>
+      <clr-toggle-wrapper *ngIf="settingsModel.useReimbursementsEnabled">
         <input
           type="checkbox"
           clrToggle

--- a/src/AplosConnector.Web/ClientApp/src/app/sync-connect/sync-connect.component.ts
+++ b/src/AplosConnector.Web/ClientApp/src/app/sync-connect/sync-connect.component.ts
@@ -169,6 +169,7 @@ export class SyncConnectComponent implements OnInit {
     syncPexFees: false,
     syncRebates: false,
     syncReimbursements: false,
+    useReimbursementsEnabled: false,
     transfersAplosContactId: 0,
     transfersAplosFundId: 0,
     transfersAplosTransactionAccountNumber: 0,

--- a/src/AplosConnector.Web/Controllers/MappingController.cs
+++ b/src/AplosConnector.Web/Controllers/MappingController.cs
@@ -72,7 +72,7 @@ namespace AplosConnector.Web.Controllers
             var mapping = await _pex2AplosMappingStorage.GetByBusinessAcctIdAsync(pexAcctId, cancellationToken);
             mapping.UpdateFromSettings(settings);
 
-            await _aplosIntegrationService.UpdateFundingSource(mapping, cancellationToken);
+            await _aplosIntegrationService.RefreshBusinessSettings(mapping, cancellationToken);
 
             await _pex2AplosMappingStorage.UpdateAsync(mapping, cancellationToken);
 
@@ -92,7 +92,7 @@ namespace AplosConnector.Web.Controllers
 
             var mapping = await _pex2AplosMappingStorage.GetByBusinessAcctIdAsync(session.PEXBusinessAcctId, cancellationToken);
 
-            await _aplosIntegrationService.UpdateFundingSource(mapping, cancellationToken);
+            await _aplosIntegrationService.RefreshBusinessSettings(mapping, cancellationToken);
 
             // Migrate legacy credit businesses: SyncInvoices used to gate everything.
             // Now that purchases and fees have their own toggles, auto-enable them

--- a/tests/AplosConnector.Common.Tests/AplosIntegrationServiceTests.cs
+++ b/tests/AplosConnector.Common.Tests/AplosIntegrationServiceTests.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 using PexCard.Api.Client.Core;
+using PexCard.Api.Client.Core.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -889,6 +890,88 @@ namespace AplosConnector.Common.Tests
 
             //Assert
             Assert.True(isConfigured, "Should be configured when SyncReimbursementsCreateContact is true even without a contact ID");
+        }
+
+        [Fact]
+        public async Task RefreshBusinessSettings_SetsUseReimbursementsEnabled_FromPexBusinessSettings()
+        {
+            //Arrange
+            var mapping = GetMapping();
+            mapping.SyncReimbursements = false; // avoid the auto-disable/persist branch, which needs live storage
+
+            _mockPexApiClient
+                .Setup(client => client.GetBusinessSettings(mapping.PEXExternalAPIToken, default))
+                .ReturnsAsync(new BusinessSettingsModel { UseReimbursements = true });
+
+            AplosIntegrationService service = GetAplosIntegrationService();
+
+            //Act
+            var result = await service.RefreshBusinessSettings(mapping, default);
+
+            //Assert
+            Assert.True(result.UseReimbursementsEnabled);
+        }
+
+        [Fact]
+        public async Task RefreshBusinessSettings_ReportsDisabled_WhenPexBusinessSettingsHasReimbursementsOff()
+        {
+            //Arrange
+            var mapping = GetMapping();
+            mapping.SyncReimbursements = false; // avoid the auto-disable/persist branch, which needs live storage
+
+            _mockPexApiClient
+                .Setup(client => client.GetBusinessSettings(mapping.PEXExternalAPIToken, default))
+                .ReturnsAsync(new BusinessSettingsModel { UseReimbursements = false });
+
+            AplosIntegrationService service = GetAplosIntegrationService();
+
+            //Act
+            var result = await service.RefreshBusinessSettings(mapping, default);
+
+            //Assert
+            Assert.False(result.UseReimbursementsEnabled);
+        }
+
+        [Fact]
+        public async Task RefreshBusinessSettings_DoesNotOverwriteFundingSource_WhenAlreadySet()
+        {
+            //Arrange
+            var mapping = GetMapping();
+            mapping.SyncReimbursements = false;
+            mapping.PEXFundingSource = FundingSource.Credit;
+
+            _mockPexApiClient
+                .Setup(client => client.GetBusinessSettings(mapping.PEXExternalAPIToken, default))
+                .ReturnsAsync(new BusinessSettingsModel { FundingSource = FundingSource.Prepaid, UseReimbursements = true });
+
+            AplosIntegrationService service = GetAplosIntegrationService();
+
+            //Act
+            var result = await service.RefreshBusinessSettings(mapping, default);
+
+            //Assert
+            Assert.Equal(FundingSource.Credit, result.PEXFundingSource);
+        }
+
+        [Fact]
+        public async Task RefreshBusinessSettings_SetsFundingSource_WhenNotYetSet()
+        {
+            //Arrange
+            var mapping = GetMapping();
+            mapping.SyncReimbursements = false;
+            mapping.PEXFundingSource = 0;
+
+            _mockPexApiClient
+                .Setup(client => client.GetBusinessSettings(mapping.PEXExternalAPIToken, default))
+                .ReturnsAsync(new BusinessSettingsModel { FundingSource = FundingSource.Prepaid, UseReimbursements = true });
+
+            AplosIntegrationService service = GetAplosIntegrationService();
+
+            //Act
+            var result = await service.RefreshBusinessSettings(mapping, default);
+
+            //Assert
+            Assert.Equal(FundingSource.Prepaid, result.PEXFundingSource);
         }
 
         private AplosIntegrationService GetAplosIntegrationService()

--- a/tests/AplosConnector.Common.Tests/AplosIntegrationServiceTests.cs
+++ b/tests/AplosConnector.Common.Tests/AplosIntegrationServiceTests.cs
@@ -893,6 +893,24 @@ namespace AplosConnector.Common.Tests
         }
 
         [Fact]
+        public async Task RefreshBusinessSettings_Throws_WhenPexCallFailsOnFirstLoad()
+        {
+            //Arrange — no prior known state (PEXFundingSource unset) to fall back to
+            var mapping = GetMapping();
+            mapping.SyncReimbursements = false;
+            mapping.PEXFundingSource = 0;
+
+            _mockPexApiClient
+                .Setup(client => client.GetBusinessSettings(mapping.PEXExternalAPIToken, default))
+                .ThrowsAsync(new Exception("PEX is down"));
+
+            AplosIntegrationService service = GetAplosIntegrationService();
+
+            //Act & Assert — surface the failure instead of silently returning an unresolved mapping
+            await Assert.ThrowsAsync<Exception>(() => service.RefreshBusinessSettings(mapping, default));
+        }
+
+        [Fact]
         public async Task RefreshBusinessSettings_SetsUseReimbursementsEnabled_FromPexBusinessSettings()
         {
             //Arrange
@@ -910,6 +928,29 @@ namespace AplosConnector.Common.Tests
 
             //Assert
             Assert.True(result.UseReimbursementsEnabled);
+        }
+
+        [Fact]
+        public async Task RefreshBusinessSettings_ReturnsMappingUnchanged_WhenPexCallThrows()
+        {
+            //Arrange
+            var mapping = GetMapping();
+            mapping.SyncReimbursements = false;
+            mapping.PEXFundingSource = FundingSource.Credit;
+            mapping.UseReimbursementsEnabled = false;
+
+            _mockPexApiClient
+                .Setup(client => client.GetBusinessSettings(mapping.PEXExternalAPIToken, default))
+                .ThrowsAsync(new Exception("PEX is down"));
+
+            AplosIntegrationService service = GetAplosIntegrationService();
+
+            //Act
+            var result = await service.RefreshBusinessSettings(mapping, default);
+
+            //Assert — degrades gracefully instead of throwing, leaving last-known values intact
+            Assert.Equal(FundingSource.Credit, result.PEXFundingSource);
+            Assert.False(result.UseReimbursementsEnabled);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- Reimbursements were shown/enabled in the Aplos setup wizard even when a business had "Use Reimbursements" disabled on CSP.
- `RefreshBusinessSettings` (renamed from `UpdateFundingSource`) now also reads the live `UseReimbursements` flag from PEX, auto-disables and persists a stale `SyncReimbursements: true` mapping when the business no longer has it enabled, and surfaces `UseReimbursementsEnabled` to the frontend.
- The wizard hides the Reimbursements toggle via `*ngIf="settingsModel.useReimbursementsEnabled"`; downstream reimbursement config sections already key off `syncReimbursements`, so they hide automatically.
- The daily sync worker (`SyncReimbursements`) now performs the same live check before doing any Aplos work, so background syncing stops for a business that disabled the feature, not just the UI.

## Work item
https://pexcard.visualstudio.com/PEX%20Processing%20Solution/_workitems/edit/144224/

## Test plan
- [x] `dotnet test tests/AplosConnector.Common.Tests` — 60 passed
- [x] `dotnet test tests/AplosConnector.Web.Tests` — 120 passed
- [x] Angular app compiles (`sync-connect.component.ts` default `settingsModel` updated for the new required field)
- [x] Manual E2E per plan: CSP disabled (never configured / previously enabled) hides toggle and turns off stale setting; CSP enabled shows toggle and config pages; flag flip mid-session reflects on reload; worker skips sync and logs the disabled reason