### PR TITLE
Aplos: sync Reimbursements when the sync start date is today

### DIFF
--- a/src/AplosConnector.Common/Services/AplosIntegrationService.cs
+++ b/src/AplosConnector.Common/Services/AplosIntegrationService.cs
@@ -2602,15 +2602,13 @@ namespace AplosConnector.Common.Services
 
             var startDateUtc = GetStartDateUtc(mapping, utcNow, _syncSettings);
             var endDateUtc = GetEndDateUtc(mapping.EndDateUtc, utcNow);
+            var (startDate, endDate) = GetEstDayWindow(startDateUtc, endDateUtc);
 
-            if (startDateUtc.Date >= endDateUtc.Date)
+            if (startDate.Date >= endDate.Date)
             {
+                logger.LogInformation($"Skipping sync reimbursements for business {mapping.PEXBusinessAcctId}. Empty sync window {startDate:yyyy-MM-dd}..{endDate:yyyy-MM-dd}.");
                 return;
             }
-
-            // Fetch Aplos transactions for dedup
-            var startDate = startDateUtc.ToStartOfDay(TimeZones.EST);
-            var aplosTransactions = await GetTransactions(mapping, startDate, cancellationToken);
 
             // Fetch Aplos reference data for tag resolution
             var aplosFunds = (await GetAplosFunds(mapping, cancellationToken)).ToList();
@@ -2676,8 +2674,8 @@ namespace AplosConnector.Common.Services
                     PaymentStatusTrigger.Returned,
                     PaymentStatusTrigger.Cancelled,
                 },
-                OutboundAchCreationStartDate = startDateUtc,
-                OutboundAchCreationEndDate = endDateUtc,
+                OutboundAchCreationStartDate = startDate,
+                OutboundAchCreationEndDate = endDate,
             };
 
             // Page through all matching payments first.
@@ -2748,12 +2746,38 @@ namespace AplosConnector.Common.Services
                 .DistinctBy(pr => pr.PaymentRequestId)
                 .ToList();
 
-            // Only sync reimbursements whose payment is fully settled (paid) and not already in Aplos.
+            // Only sync reimbursements whose payment is fully settled (paid).
             // Returned/Cancelled/in-flight requests are skipped; in-flight ones settle on a later run.
-            var reimbursementsToSync = allPaymentRequests
+            var settledReimbursements = allPaymentRequests
                 .Where(pr => pr.PaymentId.HasValue
                     && paymentTriggersByPaymentId.TryGetValue(pr.PaymentId.Value, out var trigger)
                     && trigger == PaymentStatusTrigger.Settled)
+                .ToList();
+
+            // Reimbursements post under their expense/payout date, which is independent of the
+            // outbound-ACH creation date this sync filters on: an expense incurred before the window
+            // still pays out inside it. The dedup lookup is date-scoped, so an entry written under an
+            // older post date falls outside it and the reimbursement would be re-posted on every run
+            // until its ACH date ages out. Widen the lookup to the oldest date we are about to write.
+            var dedupFromDate = startDate;
+            foreach (var settled in settledReimbursements)
+            {
+                var settledPostDate = GetReimbursementPostDate(mapping, settled).ToStartOfDay(TimeZones.EST);
+                if (settledPostDate < dedupFromDate)
+                {
+                    dedupFromDate = settledPostDate;
+                }
+            }
+
+            if (dedupFromDate < startDate)
+            {
+                logger.LogInformation($"Widening the Aplos dedup lookup from {startDate:yyyy-MM-dd} to {dedupFromDate:yyyy-MM-dd} for business {mapping.PEXBusinessAcctId} to cover back-dated reimbursements.");
+            }
+
+            // Fetch Aplos transactions for dedup
+            var aplosTransactions = await GetTransactions(mapping, dedupFromDate, cancellationToken);
+
+            var reimbursementsToSync = settledReimbursements
                 .Where(pr => !WasPexTransactionSyncedToAplos(aplosTransactions, pr.PaymentRequestId.ToString()))
                 .ToList();
 
@@ -2982,16 +3006,8 @@ namespace AplosConnector.Common.Services
                             ? paymentRequestIdString
                             : noteContent + idSuffix;
 
-                        // Determine post date
-                        DateTime postDate;
-                        if (mapping.PostDateType == PostDateType.Settlement && pr.PayoutDate.HasValue)
-                        {
-                            postDate = pr.PayoutDate.Value.DateTime;
-                        }
-                        else
-                        {
-                            postDate = pr.PurchaseDate.DateTime;
-                        }
+                        // Determine post date. Must stay in sync with the dedup window widening above.
+                        var postDate = GetReimbursementPostDate(mapping, pr);
 
                         // Determine contact — auto-create from employee name or use default
                         AplosApiContactDetail contact;
@@ -3062,6 +3078,30 @@ namespace AplosConnector.Common.Services
                 SyncNotes = syncNote
             };
             await _historyStorage.CreateAsync(result, cancellationToken);
+        }
+
+        /// <summary>
+        /// Resolves a UTC sync window onto EST day boundaries. Comparing the raw UTC dates treated a
+        /// start date of "today" as an empty window and skipped the whole run, because the default end
+        /// date is utcNow on the same UTC day (work item 144293). The purchases and business-account
+        /// syncs inline this same conversion and could adopt this helper.
+        /// </summary>
+        public static (DateTime StartDate, DateTime EndDate) GetEstDayWindow(DateTime startDateUtc, DateTime endDateUtc)
+        {
+            return (startDateUtc.ToStartOfDay(TimeZones.EST), endDateUtc.ToEndOfDay(TimeZones.EST));
+        }
+
+        /// <summary>
+        /// The Aplos post date for a reimbursement: the payout date when the mapping posts on
+        /// settlement (and PEX has one), otherwise the date the expense was incurred. Shared by the
+        /// posting loop and the dedup window so the date written can never fall outside the date
+        /// searched.
+        /// </summary>
+        public static DateTime GetReimbursementPostDate(Pex2AplosMappingModel mapping, PaymentRequestModel paymentRequest)
+        {
+            return mapping.PostDateType == PostDateType.Settlement && paymentRequest.PayoutDate.HasValue
+                ? paymentRequest.PayoutDate.Value.DateTime
+                : paymentRequest.PurchaseDate.DateTime;
         }
 
         private static TagAnswerModel GetReimbursementTagAnswer(IEnumerable<TagAnswerModel> tagAnswers, string fieldId)

--- a/tests/AplosConnector.Common.Tests/AplosIntegrationServiceTests.cs
+++ b/tests/AplosConnector.Common.Tests/AplosIntegrationServiceTests.cs
@@ -750,6 +750,125 @@ namespace AplosConnector.Common.Tests
             Assert.Equal("Resources (1004)", dedupedAccounts[3].Name);
         }
 
+        [Fact]
+        public void GetEstDayWindow_LeavesWindowOpen_WhenStartDateIsToday()
+        {
+            //Arrange — work item 144293: the daily sync runs at 03:16 UTC, so with a start date of
+            //"today" the raw UTC dates are the same calendar day and the run was skipped entirely.
+            var utcNow = new DateTime(2026, 7, 27, 3, 16, 0, DateTimeKind.Utc);
+            var startDateUtc = utcNow.Date;
+
+            //Act
+            var (startDate, endDate) = AplosIntegrationService.GetEstDayWindow(startDateUtc, utcNow);
+
+            //Assert
+            Assert.True(startDate.Date < endDate.Date, "A start date of today must still produce a syncable window.");
+        }
+
+        [Theory]
+        [InlineData(12)]
+        [InlineData(23)]
+        public void GetEstDayWindow_LeavesWindowOpen_WhenStartDateIsToday_RegardlessOfHour(int utcHour)
+        {
+            //Arrange — the skip must not come back at other times of day
+            var utcNow = new DateTime(2026, 7, 27, utcHour, 30, 0, DateTimeKind.Utc);
+            var startDateUtc = utcNow.Date;
+
+            //Act
+            var (startDate, endDate) = AplosIntegrationService.GetEstDayWindow(startDateUtc, utcNow);
+
+            //Assert
+            Assert.True(startDate.Date < endDate.Date, $"Window must stay open at {utcHour}:30 UTC.");
+        }
+
+        [Fact]
+        public void GetEstDayWindow_ClosesWindow_WhenEndDatePrecedesStartDate()
+        {
+            //Arrange — a configured end date before the start date is still a degenerate window
+            var startDateUtc = new DateTime(2026, 7, 27, 0, 0, 0, DateTimeKind.Utc);
+            var endDateUtc = new DateTime(2026, 7, 20, 0, 0, 0, DateTimeKind.Utc);
+
+            //Act
+            var (startDate, endDate) = AplosIntegrationService.GetEstDayWindow(startDateUtc, endDateUtc);
+
+            //Assert
+            Assert.True(startDate.Date >= endDate.Date);
+        }
+
+        [Fact]
+        public void GetReimbursementPostDate_UsesPurchaseDate_ByDefault()
+        {
+            //Arrange
+            var mapping = new Pex2AplosMappingModel { PostDateType = PostDateType.Transaction };
+            var purchaseDate = new DateTimeOffset(2026, 4, 15, 0, 0, 0, TimeSpan.Zero);
+            var pr = new PaymentRequestModel
+            {
+                PurchaseDate = purchaseDate,
+                PayoutDate = new DateTimeOffset(2026, 7, 20, 0, 0, 0, TimeSpan.Zero),
+            };
+
+            //Act
+            var postDate = AplosIntegrationService.GetReimbursementPostDate(mapping, pr);
+
+            //Assert
+            Assert.Equal(purchaseDate.DateTime, postDate);
+        }
+
+        [Fact]
+        public void GetReimbursementPostDate_UsesPayoutDate_WhenPostingOnSettlement()
+        {
+            //Arrange
+            var mapping = new Pex2AplosMappingModel { PostDateType = PostDateType.Settlement };
+            var payoutDate = new DateTimeOffset(2026, 7, 20, 0, 0, 0, TimeSpan.Zero);
+            var pr = new PaymentRequestModel
+            {
+                PurchaseDate = new DateTimeOffset(2026, 4, 15, 0, 0, 0, TimeSpan.Zero),
+                PayoutDate = payoutDate,
+            };
+
+            //Act
+            var postDate = AplosIntegrationService.GetReimbursementPostDate(mapping, pr);
+
+            //Assert
+            Assert.Equal(payoutDate.DateTime, postDate);
+        }
+
+        [Fact]
+        public void GetReimbursementPostDate_FallsBackToPurchaseDate_WhenSettlementHasNoPayoutDate()
+        {
+            //Arrange — this fallback is why the dedup window must be derived from the same helper
+            var mapping = new Pex2AplosMappingModel { PostDateType = PostDateType.Settlement };
+            var purchaseDate = new DateTimeOffset(2026, 4, 15, 0, 0, 0, TimeSpan.Zero);
+            var pr = new PaymentRequestModel { PurchaseDate = purchaseDate, PayoutDate = null };
+
+            //Act
+            var postDate = AplosIntegrationService.GetReimbursementPostDate(mapping, pr);
+
+            //Assert
+            Assert.Equal(purchaseDate.DateTime, postDate);
+        }
+
+        [Fact]
+        public void GetReimbursementPostDate_CanPredateSyncWindowStart_WhichIsWhyDedupMustWiden()
+        {
+            //Arrange — the PEX query filters on outbound-ACH creation date, but the post date is the
+            //expense date. An old expense paid out today posts outside the window, so a dedup lookup
+            //scoped to the window start would miss it and re-post it on every run.
+            var mapping = new Pex2AplosMappingModel { PostDateType = PostDateType.Transaction };
+            var utcNow = new DateTime(2026, 7, 27, 3, 16, 0, DateTimeKind.Utc);
+            var (windowStart, _) = AplosIntegrationService.GetEstDayWindow(utcNow.AddDays(-60), utcNow);
+            var pr = new PaymentRequestModel
+            {
+                PurchaseDate = new DateTimeOffset(2026, 4, 15, 0, 0, 0, TimeSpan.Zero), // ~100 days back
+            };
+
+            //Act
+            var postDate = AplosIntegrationService.GetReimbursementPostDate(mapping, pr);
+
+            //Assert
+            Assert.True(postDate < windowStart, "Post date must be able to precede the window start; the dedup lookup has to widen to cover it.");
+        }
+
         [Theory]
         [InlineData(0, 1, 1, "Contact not configured")]
         [InlineData(1, 0, 1, "Fund not configured")]


### PR DESCRIPTION
Fixes two bugs in `SyncReimbursements`, both from its sync window not matching the other syncs.

**Start date of today skipped the whole run** ([144293](https://pexcard.visualstudio.com/PEX%20Processing%20Solution/_workitems/edit/144293/)) — the guard compared raw UTC dates, and the default end date is `utcNow` on the same UTC day, so the window always looked empty. Now resolves both ends onto EST day boundaries first, like the purchases sync. The PEX query uses that same window instead of raw UTC.

**Reimbursements could re-post every run** — the dedup lookup is date-scoped to the sync window, but entries post under the expense date, so anything back-dated landed outside the lookup and was never found. Lookup now widens to the oldest date being written.

Reviewer notes:
- Back-dated reimbursements make the Aplos dedup query reach further back. Chose that over clamping the post date, which would misdate ledger entries.
- Found but **not** fixed here (need separate tickets): dedup token is a bare id shared with invoice/transaction ids (collision → dropped record, predates reimbursements); per-request status is never checked, so a rejected request inside a settled transfer would still post.